### PR TITLE
fix: set react-router as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:coverage": "npm run test -- --coverage"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-router": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@dcl/eslint-config": "^2.2.1",


### PR DESCRIPTION
Adds react-router as a peerDependency since usePageTracking uses useLocation from react-router.