### PR TITLE
feat: remove react-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,17 @@ function MyComponent() {
 
 #### Using the usePageTracking Hook
 
-The `usePageTracking` hook automatically tracks page views based on route changes:
+The `usePageTracking` hook tracks page views when the pathname changes. You need to pass the current pathname as a parameter:
 
 ```typescript
 import { usePageTracking } from '@dcl/hooks'
+import { useLocation } from 'react-router-dom' // or your router of choice
 
 function MyPage() {
-  // Automatically tracks page view when route changes
-  usePageTracking()
+  const location = useLocation()
+  
+  // Tracks page view when pathname changes
+  usePageTracking(location.pathname)
 
   return (
     <div>
@@ -230,10 +233,13 @@ Here's a complete example showing how to use all analytics features together:
 
 ```typescript
 import { AnalyticsProvider, useAnalytics, usePageTracking } from '@dcl/hooks'
+import { useLocation } from 'react-router-dom' // or your router of choice
 
 function MyPage() {
+  const location = useLocation()
+  
   // Track page views
-  usePageTracking()
+  usePageTracking(location.pathname)
 
   return (
     <div>
@@ -347,14 +353,17 @@ function MyComponent() {
 
 #### Using the usePageTracking Hook
 
-The `usePageTracking` hook automatically tracks page views based on route changes:
+The `usePageTracking` hook tracks page views when the pathname changes. You need to pass the current pathname as a parameter:
 
 ```typescript
 import { usePageTracking } from '@dcl/hooks'
+import { useLocation } from 'react-router-dom' // or your router of choice
 
 function MyPage() {
-  // Automatically tracks page view when route changes
-  usePageTracking()
+  const location = useLocation()
+  
+  // Tracks page view when pathname changes
+  usePageTracking(location.pathname)
 
   return (
     <div>
@@ -398,10 +407,13 @@ Here's a complete example showing how to use all analytics features together:
 
 ```typescript
 import { AnalyticsProvider, useAnalytics, usePageTracking } from '@dcl/hooks'
+import { useLocation } from 'react-router-dom' // or your router of choice
 
 function MyPage() {
+  const location = useLocation()
+  
   // Track page views
-  usePageTracking()
+  usePageTracking(location.pathname)
 
   return (
     <div>

--- a/README.md
+++ b/README.md
@@ -183,13 +183,13 @@ The `usePageTracking` hook tracks page views when the pathname changes. You need
 
 ```typescript
 import { usePageTracking } from '@dcl/hooks'
-import { useLocation } from 'react-router-dom' // or your router of choice
 
 function MyPage() {
-  const location = useLocation()
+  // Get pathname from your router or window.location
+  const pathname = typeof window !== 'undefined' ? window.location.pathname : '/'
   
   // Tracks page view when pathname changes
-  usePageTracking(location.pathname)
+  usePageTracking(pathname)
 
   return (
     <div>
@@ -197,6 +197,20 @@ function MyPage() {
       {/* Your page content */}
     </div>
   )
+}
+```
+
+If you're using a router library, you can get the pathname from it:
+
+```typescript
+import { usePageTracking } from '@dcl/hooks'
+import { useLocation } from 'react-router-dom' // React Router example
+
+function MyPage() {
+  const location = useLocation()
+  usePageTracking(location.pathname)
+  
+  return <div>My Page</div>
 }
 ```
 
@@ -233,13 +247,13 @@ Here's a complete example showing how to use all analytics features together:
 
 ```typescript
 import { AnalyticsProvider, useAnalytics, usePageTracking } from '@dcl/hooks'
-import { useLocation } from 'react-router-dom' // or your router of choice
 
 function MyPage() {
-  const location = useLocation()
+  // Get pathname from your router or window.location
+  const pathname = typeof window !== 'undefined' ? window.location.pathname : '/'
   
   // Track page views
-  usePageTracking(location.pathname)
+  usePageTracking(pathname)
 
   return (
     <div>
@@ -357,13 +371,13 @@ The `usePageTracking` hook tracks page views when the pathname changes. You need
 
 ```typescript
 import { usePageTracking } from '@dcl/hooks'
-import { useLocation } from 'react-router-dom' // or your router of choice
 
 function MyPage() {
-  const location = useLocation()
+  // Get pathname from your router or window.location
+  const pathname = typeof window !== 'undefined' ? window.location.pathname : '/'
   
   // Tracks page view when pathname changes
-  usePageTracking(location.pathname)
+  usePageTracking(pathname)
 
   return (
     <div>
@@ -371,6 +385,20 @@ function MyPage() {
       {/* Your page content */}
     </div>
   )
+}
+```
+
+If you're using a router library, you can get the pathname from it:
+
+```typescript
+import { usePageTracking } from '@dcl/hooks'
+import { useLocation } from 'react-router-dom' // React Router example
+
+function MyPage() {
+  const location = useLocation()
+  usePageTracking(location.pathname)
+  
+  return <div>My Page</div>
 }
 ```
 
@@ -407,13 +435,13 @@ Here's a complete example showing how to use all analytics features together:
 
 ```typescript
 import { AnalyticsProvider, useAnalytics, usePageTracking } from '@dcl/hooks'
-import { useLocation } from 'react-router-dom' // or your router of choice
 
 function MyPage() {
-  const location = useLocation()
+  // Get pathname from your router or window.location
+  const pathname = typeof window !== 'undefined' ? window.location.pathname : '/'
   
   // Track page views
-  usePageTracking(location.pathname)
+  usePageTracking(pathname)
 
   return (
     <div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@segment/analytics-next": "^1.79.0",
         "@sentry/browser": "^9.0.0",
         "isbot": "^5.1.25",
-        "react-router": "^7.4.0",
         "ua-parser-js": "^2.0.2"
       },
       "devDependencies": {
@@ -1802,12 +1801,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
-      "license": "MIT"
-    },
     "node_modules/@types/gensync": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.4.tgz",
@@ -2939,19 +2932,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
-    },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -6564,7 +6544,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -6803,6 +6784,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -7731,6 +7713,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7742,7 +7725,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7756,30 +7739,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "node_modules/react-router": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.4.0.tgz",
-      "integrity": "sha512-Y2g5ObjkvX3VFeVt+0CIPuYd9PpgqCslG7ASSIdN73LwA1nNWzcMLaoMRJfP3prZFI92svxFwbn7XkLJ+UPQ6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/cookie": "^0.6.0",
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0",
-        "turbo-stream": "2.4.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -8085,7 +8044,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -8098,12 +8057,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -8764,12 +8717,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-    },
-    "node_modules/turbo-stream": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
-      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
-      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@segment/analytics-next": "^1.79.0",
     "@sentry/browser": "^9.0.0",
     "isbot": "^5.1.25",
-    "react-router": "^7.4.0",
     "ua-parser-js": "^2.0.2"
   },
   "keywords": [

--- a/src/hooks/usePageTracking.ts
+++ b/src/hooks/usePageTracking.ts
@@ -1,14 +1,34 @@
-import { useEffect } from "react"
-import { useLocation } from "react-router"
+import { useEffect, useState } from "react"
 import { useAnalytics } from "./useAnalytics"
 
-const usePageTracking = () => {
-  const location = useLocation()
+const usePageTracking = (pathname?: string) => {
   const { page } = useAnalytics()
+  const [currentPathname, setCurrentPathname] = useState(
+    pathname ?? (typeof window !== "undefined" ? window.location.pathname : "")
+  )
 
   useEffect(() => {
-    page(location.pathname)
-  }, [location, page])
+    if (pathname !== undefined) {
+      setCurrentPathname(pathname)
+      return
+    }
+
+    const updatePathname = () => {
+      setCurrentPathname(window.location.pathname)
+    }
+
+    updatePathname()
+
+    window.addEventListener("popstate", updatePathname)
+
+    return () => {
+      window.removeEventListener("popstate", updatePathname)
+    }
+  }, [pathname])
+
+  useEffect(() => {
+    page(currentPathname)
+  }, [currentPathname, page])
 }
 
 export { usePageTracking }

--- a/src/hooks/usePageTracking.ts
+++ b/src/hooks/usePageTracking.ts
@@ -1,34 +1,12 @@
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { useAnalytics } from "./useAnalytics"
 
-const usePageTracking = (pathname?: string) => {
+const usePageTracking = (path: string) => {
   const { page } = useAnalytics()
-  const [currentPathname, setCurrentPathname] = useState(
-    pathname ?? (typeof window !== "undefined" ? window.location.pathname : "")
-  )
 
   useEffect(() => {
-    if (pathname !== undefined) {
-      setCurrentPathname(pathname)
-      return
-    }
-
-    const updatePathname = () => {
-      setCurrentPathname(window.location.pathname)
-    }
-
-    updatePathname()
-
-    window.addEventListener("popstate", updatePathname)
-
-    return () => {
-      window.removeEventListener("popstate", updatePathname)
-    }
-  }, [pathname])
-
-  useEffect(() => {
-    page(currentPathname)
-  }, [currentPathname, page])
+    page(path)
+  }, [page])
 }
 
 export { usePageTracking }


### PR DESCRIPTION
Removes the `react-router` dependency by refactoring `usePageTracking` to be router-agnostic.

### Changes

- **Refactored `usePageTracking`**: Now accepts an optional `pathname` parameter. When not provided, uses `window.location.pathname` and listens to `popstate` events
- **Updated tests**: Removed `MemoryRouter` dependency, tests now pass `pathname` directly
- **Removed `react-router` from `devDependencies`**

### Usage
// With explicit pathname (works with any router)
usePageTracking(location.pathname)

// Automatic using window.location
usePageTracking()