### PR TITLE
feat: useTranslation hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ function App() {
 
 ### useTranslation
 
-The `useTranslation` hook provides i18n capabilities powered by `react-intl`, giving you access to advanced formatting functions for numbers, dates, currencies, and more.
+The `useTranslation` hook provides i18n capabilities powered by `@formatjs/intl`, giving you access to advanced formatting functions for numbers, dates, currencies, and more.
 
 Basic usage:
 

--- a/README.md
+++ b/README.md
@@ -467,22 +467,28 @@ function App() {
 
 ### useTranslation
 
+The `useTranslation` hook provides i18n capabilities powered by `react-intl`, giving you access to advanced formatting functions for numbers, dates, currencies, and more.
+
+Basic usage:
+
 ```typescript
 import { useTranslation } from '@dcl/hooks'
 
 const translations = {
   en: {
     greeting: 'Hello, {name}!',
-    welcome: 'Welcome to our app'
+    welcome: 'Welcome to our app',
+    items: '{count, plural, =0 {No items} one {# item} other {# items}}'
   },
   es: {
     greeting: 'Hola, {name}!',
-    welcome: 'Bienvenido a nuestra aplicación'
+    welcome: 'Bienvenido a nuestra aplicación',
+    items: '{count, plural, =0 {Sin elementos} one {# elemento} other {# elementos}}'
   }
 }
 
 function MyComponent() {
-  const { t, locale, setLocale } = useTranslation({
+  const { t, intl, locale, setLocale } = useTranslation({
     locale: 'en',
     translations
   })
@@ -490,10 +496,51 @@ function MyComponent() {
   return (
     <div>
       <p>{t('greeting', { name: 'John' })}</p>
-      <p>{t('welcome')}</p>
+      <p>{t('items', { count: 5 })}</p>
       <button onClick={() => setLocale('es')}>
         Switch to Spanish
       </button>
+    </div>
+  )
+}
+```
+
+Using the `intl` object for advanced formatting:
+
+```typescript
+function AdvancedFormattingExample() {
+  const { t, intl } = useTranslation({
+    locale: 'en',
+    translations: {
+      en: {
+        product_price: 'Price: {price}'
+      }
+    }
+  })
+
+  return (
+    <div>
+      {/* Format numbers */}
+      <p>Count: {intl.formatNumber(1000)}</p>
+
+      {/* Format dates */}
+      <p>Today: {intl.formatDate(new Date(), {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      })}</p>
+
+      {/* Format currency */}
+      <p>{intl.formatNumber(99.99, {
+        style: 'currency',
+        currency: 'USD'
+      })}</p>
+
+      {/* Format relative time */}
+      <p>{intl.formatRelativeTime(-1, 'day')}</p>
+
+      {/* Use formatMessage directly */}
+      <p>{intl.formatMessage({ id: 'product_price' }, { price: '$99' })}</p>
     </div>
   )
 }

--- a/README.md
+++ b/README.md
@@ -576,6 +576,108 @@ function MyComponent() {
 }
 ```
 
+Using TranslationProvider for context-based translations:
+
+```typescript
+import { TranslationProvider, useTranslation } from '@dcl/hooks'
+
+const translations = {
+  en: {
+    greeting: 'Hello!',
+    welcome: 'Welcome to our app'
+  },
+  es: {
+    greeting: 'Hola!',
+    welcome: 'Bienvenido a nuestra aplicación'
+  }
+}
+
+function App() {
+  return (
+    <TranslationProvider
+      locale="en"
+      translations={translations}
+      fallbackLocale="en"
+    >
+      <MyComponent />
+    </TranslationProvider>
+  )
+}
+
+function MyComponent() {
+  // Can be used without options when inside TranslationProvider
+  const { t, locale, setLocale } = useTranslation()
+
+  return (
+    <div>
+      <p>{t('greeting')}</p>
+      <p>{t('welcome')}</p>
+      <button onClick={() => setLocale('es')}>
+        Switch to Spanish
+      </button>
+    </div>
+  )
+}
+```
+
+Using ICU Message Syntax:
+
+```typescript
+const translations = {
+  en: {
+    // Pluralization
+    items: '{count, plural, =0 {No items} one {# item} other {# items}}',
+    // Select syntax
+    gender: '{gender, select, male {He} female {She} other {They}}',
+    // Complex ICU
+    notification: '{count, plural, =0 {No notifications} =1 {You have one notification} other {You have # notifications}}'
+  }
+}
+
+function MyComponent() {
+  const { t } = useTranslation({
+    locale: 'en',
+    translations
+  })
+
+  return (
+    <div>
+      <p>{t('items', { count: 0 })}</p> {/* "No items" */}
+      <p>{t('items', { count: 1 })}</p> {/* "1 item" */}
+      <p>{t('items', { count: 5 })}</p> {/* "5 items" */}
+      <p>{t('gender', { gender: 'male' })}</p> {/* "He" */}
+      <p>{t('notification', { count: 3 })}</p> {/* "You have 3 notifications" */}
+    </div>
+  )
+}
+```
+
+Additional intl formatting functions:
+
+```typescript
+function MyComponent() {
+  const { intl } = useTranslation({
+    locale: 'en',
+    translations: { en: {} }
+  })
+
+  return (
+    <div>
+      {/* Format lists */}
+      <p>{intl.formatList(['apple', 'banana', 'orange'])}</p>
+      {/* "apple, banana, and orange" */}
+
+      {/* Format display names */}
+      <p>{intl.formatDisplayName('es', { type: 'language' })}</p>
+      {/* "Spanish" */}
+      
+      <p>{intl.formatDisplayName('US', { type: 'region' })}</p>
+      {/* "United States" */}
+    </div>
+  )
+}
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm install @dcl/hooks
 - `useAsyncEffect`: Async version of useEffect
 - `useAsyncMemo`: Async version of useMemo
 - `useInfiniteScroll`: Infinite scroll functionality for loading more content
+- `useTranslation`: Simple and lightweight translation management
 
 ## Examples
 
@@ -460,6 +461,70 @@ function App() {
     >
       <MyPage />
     </AnalyticsProvider>
+  )
+}
+```
+
+### useTranslation
+
+```typescript
+import { useTranslation } from '@dcl/hooks'
+
+const translations = {
+  en: {
+    greeting: 'Hello, {name}!',
+    welcome: 'Welcome to our app'
+  },
+  es: {
+    greeting: 'Hola, {name}!',
+    welcome: 'Bienvenido a nuestra aplicación'
+  }
+}
+
+function MyComponent() {
+  const { t, locale, setLocale } = useTranslation({
+    locale: 'en',
+    translations
+  })
+
+  return (
+    <div>
+      <p>{t('greeting', { name: 'John' })}</p>
+      <p>{t('welcome')}</p>
+      <button onClick={() => setLocale('es')}>
+        Switch to Spanish
+      </button>
+    </div>
+  )
+}
+```
+
+With fallback locale:
+
+```typescript
+const translations = {
+  en: {
+    greeting: 'Hello!',
+    welcome: 'Welcome!'
+  },
+  es: {
+    greeting: 'Hola!'
+    // 'welcome' is missing in Spanish
+  }
+}
+
+function MyComponent() {
+  const { t } = useTranslation({
+    locale: 'es',
+    translations,
+    fallbackLocale: 'en' // Will use English if translation is missing
+  })
+
+  return (
+    <div>
+      <p>{t('greeting')}</p> {/* Shows: "Hola!" */}
+      <p>{t('welcome')}</p> {/* Shows: "Welcome!" (from fallback) */}
+    </div>
   )
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
+        "@formatjs/intl": "^3.1.8",
         "@segment/analytics-next": "^1.79.0",
         "@sentry/browser": "^9.0.0",
         "isbot": "^5.1.25",
-        "react-intl": "^6.8.3",
         "ua-parser-js": "^2.0.2"
       },
       "devDependencies": {
@@ -887,62 +887,61 @@
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.0.tgz",
-      "integrity": "sha512-IpM+ev1E4QLtstniOE29W1rqH9eTdx5hQdNL8pzrflMj/gogfaoONZqL83LUeQScHAvyMbpqP5C9MzNf+fFwhQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "2.2.1",
-        "@formatjs/intl-localematcher": "0.5.5",
-        "tslib": "^2.7.0"
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.1.tgz",
-      "integrity": "sha512-XS2RcOSyWxmUB7BUjj3mlPH0exsUzlf6QfhhijgI941WaJhVxXQ6mEWkdUFIdnKi3TuTYxRdelsgv3mjieIGIA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.7.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.0.tgz",
-      "integrity": "sha512-aHPysZTUbsuMyrUcjDzG2IfxCycXMnSew1h3r9PcVQAEr1Fo9Jke0Jkyn74DlU21MQZAgWgTfybgO0Y7gVSzQQ==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.0",
-        "@formatjs/icu-skeleton-parser": "1.8.4",
-        "tslib": "^2.7.0"
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.4.tgz",
-      "integrity": "sha512-LMQ1+Wk1QSzU4zpd5aSu7+w5oeYhupRwZnMQckLPRYhSjf2/8JWQ882BauY9NyHxs5igpuQIXZDgfkaH3PoATg==",
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.0",
-        "tslib": "^2.7.0"
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@formatjs/intl": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.10.tgz",
-      "integrity": "sha512-yh8rjP5dYUo4P2B61u37xG0QqAAuiwM0UgH0GXSs73gdOr02C+/h3hgJ+ZH7hN/hWPLt5R1r3/HLM95W3y+LcQ==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-3.1.8.tgz",
+      "integrity": "sha512-LWXgwI5zTMatvR8w8kCNh/priDTOF/ZssokMBHJ7ZWXFoYLVOYo0EJERD9Eajv+xsfQO1QkuAt77KWQ1OI4mOQ==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.0",
-        "@formatjs/fast-memoize": "2.2.1",
-        "@formatjs/icu-messageformat-parser": "2.9.0",
-        "@formatjs/intl-displaynames": "6.8.0",
-        "@formatjs/intl-listformat": "7.7.0",
-        "intl-messageformat": "10.7.2",
-        "tslib": "^2.7.0"
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "intl-messageformat": "10.7.18",
+        "tslib": "^2.8.0"
       },
       "peerDependencies": {
-        "typescript": "^4.7 || 5"
+        "typescript": "^5.6.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -950,35 +949,13 @@
         }
       }
     },
-    "node_modules/@formatjs/intl-displaynames": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.8.0.tgz",
-      "integrity": "sha512-cVnZbu+JltdgPrKQL3PdWQk+5ESsWsBo1vBKHNzZuehayFZLeJmd5u38rjj0duXvjTInUuUO0M8tjBLeG+2YgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.0",
-        "@formatjs/intl-localematcher": "0.5.5",
-        "tslib": "^2.7.0"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.7.0.tgz",
-      "integrity": "sha512-vP/uP2xQmqRdQpEeE89/K1vYy3ditrwAq6junfq0We/4qgmfa81jpYDV/RO/hQwrzlRdh+6hEkdcfkJrJ+qtaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.0",
-        "@formatjs/intl-localematcher": "0.5.5",
-        "tslib": "^2.7.0"
-      }
-    },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.5.tgz",
-      "integrity": "sha512-t5tOGMgZ/i5+ALl2/offNqAQq/lfUnKLEw0mXQI4N4bqpedhrSE+fyKLpwnd22sK0dif6AV+ufQcTsKShB9J1g==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.7.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1912,18 +1889,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
-      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "license": "MIT",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2033,12 +1998,14 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3101,7 +3068,8 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -3222,8 +3190,7 @@
     "node_modules/decimal.js": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "dev": true
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
     },
     "node_modules/dedent": {
       "version": "1.5.3",
@@ -4903,21 +4870,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -5068,15 +5020,15 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.7.2",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.2.tgz",
-      "integrity": "sha512-DtzI0Vvwla57No1lhG6+heaL4C8tBM3rKzuSMm+r5P0gSJSyCFBbRdqhE/j+kywrMmkGYe4jYKDCbRWXpDez2g==",
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.0",
-        "@formatjs/fast-memoize": "2.2.1",
-        "@formatjs/icu-messageformat-parser": "2.9.0",
-        "tslib": "^2.7.0"
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/is-arguments": {
@@ -6676,7 +6628,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -6915,6 +6868,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -7843,6 +7797,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7861,33 +7816,6 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-intl": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.8.3.tgz",
-      "integrity": "sha512-JN2L/NwCFqSMoQXhJTF+bYOoT+wqPe/gsgyHyFNaC310tnDo41fYSMcMskzYghZkZBtlkfdoCMmfvtAMtwK4ww==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.9.0",
-        "@formatjs/intl": "2.10.10",
-        "@formatjs/intl-displaynames": "6.8.0",
-        "@formatjs/intl-listformat": "7.7.0",
-        "@types/hoist-non-react-statics": "3",
-        "@types/react": "^18.3.11",
-        "hoist-non-react-statics": "3",
-        "intl-messageformat": "10.7.2",
-        "tslib": "^2.7.0"
-      },
-      "peerDependencies": {
-        "react": "^16.6.0 || 17 || 18",
-        "typescript": "^4.7 || 5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@segment/analytics-next": "^1.79.0",
         "@sentry/browser": "^9.0.0",
         "isbot": "^5.1.25",
+        "react-intl": "^6.8.3",
         "ua-parser-js": "^2.0.2"
       },
       "devDependencies": {
@@ -883,6 +884,101 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.0.tgz",
+      "integrity": "sha512-IpM+ev1E4QLtstniOE29W1rqH9eTdx5hQdNL8pzrflMj/gogfaoONZqL83LUeQScHAvyMbpqP5C9MzNf+fFwhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.1",
+        "@formatjs/intl-localematcher": "0.5.5",
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.1.tgz",
+      "integrity": "sha512-XS2RcOSyWxmUB7BUjj3mlPH0exsUzlf6QfhhijgI941WaJhVxXQ6mEWkdUFIdnKi3TuTYxRdelsgv3mjieIGIA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.0.tgz",
+      "integrity": "sha512-aHPysZTUbsuMyrUcjDzG2IfxCycXMnSew1h3r9PcVQAEr1Fo9Jke0Jkyn74DlU21MQZAgWgTfybgO0Y7gVSzQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "@formatjs/icu-skeleton-parser": "1.8.4",
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.4.tgz",
+      "integrity": "sha512-LMQ1+Wk1QSzU4zpd5aSu7+w5oeYhupRwZnMQckLPRYhSjf2/8JWQ882BauY9NyHxs5igpuQIXZDgfkaH3PoATg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@formatjs/intl": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.10.tgz",
+      "integrity": "sha512-yh8rjP5dYUo4P2B61u37xG0QqAAuiwM0UgH0GXSs73gdOr02C+/h3hgJ+ZH7hN/hWPLt5R1r3/HLM95W3y+LcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "@formatjs/fast-memoize": "2.2.1",
+        "@formatjs/icu-messageformat-parser": "2.9.0",
+        "@formatjs/intl-displaynames": "6.8.0",
+        "@formatjs/intl-listformat": "7.7.0",
+        "intl-messageformat": "10.7.2",
+        "tslib": "^2.7.0"
+      },
+      "peerDependencies": {
+        "typescript": "^4.7 || 5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@formatjs/intl-displaynames": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.8.0.tgz",
+      "integrity": "sha512-cVnZbu+JltdgPrKQL3PdWQk+5ESsWsBo1vBKHNzZuehayFZLeJmd5u38rjj0duXvjTInUuUO0M8tjBLeG+2YgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "@formatjs/intl-localematcher": "0.5.5",
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@formatjs/intl-listformat": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.7.0.tgz",
+      "integrity": "sha512-vP/uP2xQmqRdQpEeE89/K1vYy3ditrwAq6junfq0We/4qgmfa81jpYDV/RO/hQwrzlRdh+6hEkdcfkJrJ+qtaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "@formatjs/intl-localematcher": "0.5.5",
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.5.tgz",
+      "integrity": "sha512-t5tOGMgZ/i5+ALl2/offNqAQq/lfUnKLEw0mXQI4N4bqpedhrSE+fyKLpwnd22sK0dif6AV+ufQcTsKShB9J1g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1816,6 +1912,18 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
+      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -1925,14 +2033,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2995,8 +3101,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -4798,6 +4903,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -4945,6 +5065,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.2.tgz",
+      "integrity": "sha512-DtzI0Vvwla57No1lhG6+heaL4C8tBM3rKzuSMm+r5P0gSJSyCFBbRdqhE/j+kywrMmkGYe4jYKDCbRWXpDez2g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "@formatjs/fast-memoize": "2.2.1",
+        "@formatjs/icu-messageformat-parser": "2.9.0",
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/is-arguments": {
@@ -6544,8 +6676,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -6784,7 +6915,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -7713,7 +7843,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7732,6 +7861,33 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-intl": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.8.3.tgz",
+      "integrity": "sha512-JN2L/NwCFqSMoQXhJTF+bYOoT+wqPe/gsgyHyFNaC310tnDo41fYSMcMskzYghZkZBtlkfdoCMmfvtAMtwK4ww==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.0",
+        "@formatjs/icu-messageformat-parser": "2.9.0",
+        "@formatjs/intl": "2.10.10",
+        "@formatjs/intl-displaynames": "6.8.0",
+        "@formatjs/intl-listformat": "7.7.0",
+        "@types/hoist-non-react-statics": "3",
+        "@types/react": "^18.3.11",
+        "hoist-non-react-statics": "3",
+        "intl-messageformat": "10.7.2",
+        "tslib": "^2.7.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || 17 || 18",
+        "typescript": "^4.7 || 5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {
@@ -8829,7 +8985,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
     "typescript-eslint": "^7.15.0"
   },
   "dependencies": {
+    "@formatjs/intl": "^3.1.8",
     "@segment/analytics-next": "^1.79.0",
     "@sentry/browser": "^9.0.0",
     "isbot": "^5.1.25",
-    "react-intl": "^6.8.3",
     "ua-parser-js": "^2.0.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@segment/analytics-next": "^1.79.0",
     "@sentry/browser": "^9.0.0",
     "isbot": "^5.1.25",
+    "react-intl": "^6.8.3",
     "ua-parser-js": "^2.0.2"
   },
   "keywords": [

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,4 +1,5 @@
 export * from "./analytics/AnalyticsProvider"
 export type * from "./analytics/types"
+export * from "./translation/TranslationContext"
 export * from "./translation/TranslationProvider"
 export type * from "./translation/types"

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,2 +1,4 @@
 export * from "./analytics/AnalyticsProvider"
 export type * from "./analytics/types"
+export * from "./translation/TranslationProvider"
+export type * from "./translation/types"

--- a/src/contexts/translation/TranslationContext.ts
+++ b/src/contexts/translation/TranslationContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from "react"
+import type { TranslationContextType } from "./types"
+
+const TranslationContext = createContext<TranslationContextType | null>(null)
+
+export { TranslationContext }

--- a/src/contexts/translation/TranslationProvider.tsx
+++ b/src/contexts/translation/TranslationProvider.tsx
@@ -1,0 +1,30 @@
+import { createContext, useMemo } from "react"
+import { useTranslation } from "../../hooks/useTranslation"
+import type { TranslationContextType, TranslationProviderProps } from "./types"
+
+const TranslationContext = createContext<TranslationContextType | null>(null)
+
+const TranslationProvider = <L extends string = string>(
+  props: TranslationProviderProps<L>
+) => {
+  const { locale, translations, fallbackLocale, children } = props
+
+  const translationResult = useTranslation({
+    locale,
+    translations,
+    fallbackLocale,
+  })
+
+  const contextValue = useMemo<TranslationContextType>(
+    () => translationResult,
+    [translationResult]
+  )
+
+  return (
+    <TranslationContext.Provider value={contextValue}>
+      {children}
+    </TranslationContext.Provider>
+  )
+}
+
+export { TranslationContext, TranslationProvider }

--- a/src/contexts/translation/TranslationProvider.tsx
+++ b/src/contexts/translation/TranslationProvider.tsx
@@ -1,8 +1,7 @@
-import { createContext, useMemo } from "react"
+import { useMemo } from "react"
+import { TranslationContext } from "./TranslationContext"
 import { useTranslation } from "../../hooks/useTranslation"
 import type { TranslationContextType, TranslationProviderProps } from "./types"
-
-const TranslationContext = createContext<TranslationContextType | null>(null)
 
 const TranslationProvider = <L extends string = string>(
   props: TranslationProviderProps<L>
@@ -27,4 +26,4 @@ const TranslationProvider = <L extends string = string>(
   )
 }
 
-export { TranslationContext, TranslationProvider }
+export { TranslationProvider }

--- a/src/contexts/translation/types.ts
+++ b/src/contexts/translation/types.ts
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react"
+import type { LanguageTranslations } from "../../hooks/useTranslation"
+
+type TranslationProviderProps<L extends string = string> = {
+  locale: L
+  translations: LanguageTranslations
+  fallbackLocale?: L
+  children: ReactNode
+}
+
+type TranslationContextType = {
+  t: (key: string, values?: Record<string, string | number>) => string
+  intl: import("@formatjs/intl").IntlShape
+  locale: string
+  setLocale: (locale: string) => void
+  error: string | null
+}
+
+export type { TranslationProviderProps, TranslationContextType }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,6 +3,13 @@ export type { AdvancedNavigatorUAData } from "./useAdvancedUserAgentData"
 export type { AsyncMemoResult, AsyncMemoResultState } from "./useAsyncMemo"
 export type { AsyncStateResult, AsyncStateResultState } from "./useAsyncState"
 export type { UseInfiniteScrollOptions } from "./useInfiniteScroll"
+export type {
+  Translations,
+  LanguageTranslations,
+  TranslationState,
+  TranslationOptions,
+  TranslationResult,
+} from "./useTranslation"
 
 // Hooks
 export { useAdvancedUserAgentData } from "./useAdvancedUserAgentData"
@@ -15,3 +22,4 @@ export { useAsyncTasks } from "./useAsyncTasks"
 export { useInfiniteScroll } from "./useInfiniteScroll"
 export { usePageTracking } from "./usePageTracking"
 export { usePatchState } from "./usePatchState"
+export { useTranslation } from "./useTranslation"

--- a/src/hooks/useTranslation/index.ts
+++ b/src/hooks/useTranslation/index.ts
@@ -1,0 +1,8 @@
+export { useTranslation } from "./useTranslation"
+export type {
+  Translations,
+  LanguageTranslations,
+  TranslationState,
+  TranslationOptions,
+  TranslationResult,
+} from "./useTranslation.type"

--- a/src/hooks/useTranslation/useTranslation.ts
+++ b/src/hooks/useTranslation/useTranslation.ts
@@ -5,7 +5,7 @@ import {
   TranslationResult,
   TranslationState,
 } from "./useTranslation.type"
-import { TranslationContext } from "../../contexts/translation/TranslationProvider"
+import { TranslationContext } from "../../contexts/translation/TranslationContext"
 
 // Create a cache for @formatjs/intl to improve performance
 const cache = createIntlCache()

--- a/src/hooks/useTranslation/useTranslation.ts
+++ b/src/hooks/useTranslation/useTranslation.ts
@@ -1,16 +1,16 @@
 import { useCallback, useMemo, useState } from "react"
-import { createIntl, createIntlCache } from "react-intl"
+import { createIntl, createIntlCache } from "@formatjs/intl"
 import {
   TranslationOptions,
   TranslationResult,
   TranslationState,
 } from "./useTranslation.type"
 
-// Create a cache for react-intl to improve performance
+// Create a cache for @formatjs/intl to improve performance
 const cache = createIntlCache()
 
 /**
- * Hook to manage translations in a React application using react-intl
+ * Hook to manage translations in a React application using @formatjs/intl
  *
  * @param options - Configuration options for translations
  * @param options.locale - The initial locale to use

--- a/src/hooks/useTranslation/useTranslation.ts
+++ b/src/hooks/useTranslation/useTranslation.ts
@@ -1,0 +1,131 @@
+import { useCallback, useState } from "react"
+import {
+  TranslationOptions,
+  TranslationResult,
+  TranslationState,
+} from "./useTranslation.type"
+
+/**
+ * Simple interpolation function to replace placeholders in translation strings
+ * @param text - The translation string with placeholders like {name}
+ * @param values - The values to interpolate
+ * @returns The interpolated string
+ */
+const interpolate = (
+  text: string,
+  values?: Record<string, string | number>
+): string => {
+  if (!values) return text
+
+  return Object.entries(values).reduce((result, [key, value]) => {
+    const regex = new RegExp(`\\{${key}\\}`, "g")
+    return result.replace(regex, String(value))
+  }, text)
+}
+
+/**
+ * Hook to manage translations in a React application
+ *
+ * @param options - Configuration options for translations
+ * @param options.locale - The initial locale to use
+ * @param options.translations - An object containing all translations for all locales
+ * @param options.fallbackLocale - Optional fallback locale if a translation is not found
+ *
+ * @returns An object with translation utilities
+ *
+ * @example
+ * ```tsx
+ * const translations = {
+ *   en: {
+ *     "greeting": "Hello, {name}!",
+ *     "welcome": "Welcome to our app"
+ *   },
+ *   es: {
+ *     "greeting": "Hola, {name}!",
+ *     "welcome": "Bienvenido a nuestra aplicación"
+ *   }
+ * }
+ *
+ * function MyComponent() {
+ *   const { t, locale, setLocale } = useTranslation({
+ *     locale: 'en',
+ *     translations
+ *   })
+ *
+ *   return (
+ *     <div>
+ *       <p>{t('greeting', { name: 'John' })}</p>
+ *       <button onClick={() => setLocale('es')}>Switch to Spanish</button>
+ *     </div>
+ *   )
+ * }
+ * ```
+ */
+const useTranslation = <L extends string = string>(
+  options: TranslationOptions<L>
+): TranslationResult => {
+  const [state, setState] = useState<TranslationState<L>>({
+    locale: options.locale,
+    translations: options.translations,
+    loading: false,
+    error: null,
+  })
+
+  const t = useCallback(
+    (key: string, values?: Record<string, string | number>): string => {
+      const currentTranslations = state.translations[state.locale]
+
+      if (currentTranslations && currentTranslations[key]) {
+        return interpolate(currentTranslations[key], values)
+      }
+
+      if (options.fallbackLocale && state.locale !== options.fallbackLocale) {
+        const fallbackTranslations = state.translations[options.fallbackLocale]
+        if (fallbackTranslations && fallbackTranslations[key]) {
+          console.warn(
+            `Translation key "${key}" not found for locale "${state.locale}", using fallback locale "${options.fallbackLocale}"`
+          )
+          return interpolate(fallbackTranslations[key], values)
+        }
+      }
+
+      console.warn(
+        `Translation key "${key}" not found for locale "${state.locale}"`
+      )
+      return key
+    },
+    [state.locale, state.translations, options.fallbackLocale]
+  )
+
+  const setLocale = useCallback(
+    (newLocale: string) => {
+      if (!state.translations[newLocale]) {
+        console.error(
+          `Locale "${newLocale}" not found in translations. Available locales: ${Object.keys(state.translations).join(", ")}`
+        )
+        setState((current) => ({
+          ...current,
+          error: `Locale "${newLocale}" not found`,
+        }))
+        return
+      }
+
+      setState((current) => ({
+        ...current,
+        locale: newLocale as L,
+        error: null,
+      }))
+    },
+    [state.translations]
+  )
+
+  return {
+    t,
+    locale: state.locale,
+    setLocale,
+    loading: state.loading,
+    error: state.error,
+  }
+}
+
+export { useTranslation }

--- a/src/hooks/useTranslation/useTranslation.type.ts
+++ b/src/hooks/useTranslation/useTranslation.type.ts
@@ -1,3 +1,5 @@
+import type { IntlShape } from "react-intl"
+
 type Translations = Record<string, string>
 
 type LanguageTranslations = Record<string, Translations>
@@ -17,6 +19,7 @@ type TranslationOptions<L extends string = string> = {
 
 type TranslationResult = {
   t: (key: string, values?: Record<string, string | number>) => string
+  intl: IntlShape
   locale: string
   setLocale: (locale: string) => void
   loading: boolean

--- a/src/hooks/useTranslation/useTranslation.type.ts
+++ b/src/hooks/useTranslation/useTranslation.type.ts
@@ -7,7 +7,6 @@ type LanguageTranslations = Record<string, Translations>
 type TranslationState<L extends string = string> = {
   locale: L
   translations: LanguageTranslations
-  loading: boolean
   error: string | null
 }
 
@@ -22,14 +21,13 @@ type TranslationResult = {
   intl: IntlShape
   locale: string
   setLocale: (locale: string) => void
-  loading: boolean
   error: string | null
 }
 
 export type {
-  Translations,
   LanguageTranslations,
-  TranslationState,
   TranslationOptions,
   TranslationResult,
+  TranslationState,
+  Translations,
 }

--- a/src/hooks/useTranslation/useTranslation.type.ts
+++ b/src/hooks/useTranslation/useTranslation.type.ts
@@ -1,0 +1,32 @@
+type Translations = Record<string, string>
+
+type LanguageTranslations = Record<string, Translations>
+
+type TranslationState<L extends string = string> = {
+  locale: L
+  translations: LanguageTranslations
+  loading: boolean
+  error: string | null
+}
+
+type TranslationOptions<L extends string = string> = {
+  locale: L
+  translations: LanguageTranslations
+  fallbackLocale?: L
+}
+
+type TranslationResult = {
+  t: (key: string, values?: Record<string, string | number>) => string
+  locale: string
+  setLocale: (locale: string) => void
+  loading: boolean
+  error: string | null
+}
+
+export type {
+  Translations,
+  LanguageTranslations,
+  TranslationState,
+  TranslationOptions,
+  TranslationResult,
+}

--- a/src/hooks/useTranslation/useTranslation.type.ts
+++ b/src/hooks/useTranslation/useTranslation.type.ts
@@ -1,4 +1,4 @@
-import type { IntlShape } from "react-intl"
+import type { IntlShape } from "@formatjs/intl"
 
 type Translations = Record<string, string>
 

--- a/test/hooks/useTranslation.test.ts
+++ b/test/hooks/useTranslation.test.ts
@@ -226,7 +226,6 @@ describe("useTranslation", () => {
   describe("when a translation key is not found", () => {
     describe("and no fallback locale is configured", () => {
       let mockTranslations: LanguageTranslations
-      let consoleWarnSpy: jest.SpyInstance
 
       beforeEach(() => {
         mockTranslations = {
@@ -234,7 +233,6 @@ describe("useTranslation", () => {
             simple: "Simple text",
           },
         }
-        consoleWarnSpy = jest.spyOn(console, "warn")
       })
 
       it("should return the key itself", () => {
@@ -249,27 +247,11 @@ describe("useTranslation", () => {
 
         expect(translation).toBe("nonexistent.key")
       })
-
-      it("should log a warning with the missing key and locale", () => {
-        const { result } = renderHook(() =>
-          useTranslation({
-            locale: "en",
-            translations: mockTranslations,
-          })
-        )
-
-        result.current.t("nonexistent.key")
-
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
-          'Translation key "nonexistent.key" not found for locale "en"'
-        )
-      })
     })
 
     describe("and a fallback locale is configured", () => {
       describe("and the key exists in the fallback locale", () => {
         let mockTranslations: LanguageTranslations
-        let consoleWarnSpy: jest.SpyInstance
 
         beforeEach(() => {
           mockTranslations = {
@@ -280,7 +262,6 @@ describe("useTranslation", () => {
               greeting: "Bonjour!",
             },
           }
-          consoleWarnSpy = jest.spyOn(console, "warn")
         })
 
         it("should return the translation from the fallback locale", () => {
@@ -296,27 +277,10 @@ describe("useTranslation", () => {
 
           expect(translation).toBe("Welcome to our app")
         })
-
-        it("should log a warning about using the fallback locale", () => {
-          const { result } = renderHook(() =>
-            useTranslation({
-              locale: "fr",
-              translations: mockTranslations,
-              fallbackLocale: "en",
-            })
-          )
-
-          result.current.t("welcome")
-
-          expect(consoleWarnSpy).toHaveBeenCalledWith(
-            'Translation key "welcome" not found for locale "fr", using fallback locale "en"'
-          )
-        })
       })
 
       describe("and the key does not exist in the fallback locale", () => {
         let mockTranslations: LanguageTranslations
-        let consoleWarnSpy: jest.SpyInstance
 
         beforeEach(() => {
           mockTranslations = {
@@ -327,7 +291,6 @@ describe("useTranslation", () => {
               greeting: "Bonjour!",
             },
           }
-          consoleWarnSpy = jest.spyOn(console, "warn")
         })
 
         it("should return the key itself", () => {
@@ -343,21 +306,64 @@ describe("useTranslation", () => {
 
           expect(translation).toBe("nonexistent.key")
         })
-
-        it("should log a warning", () => {
-          const { result } = renderHook(() =>
-            useTranslation({
-              locale: "fr",
-              translations: mockTranslations,
-              fallbackLocale: "en",
-            })
-          )
-
-          result.current.t("nonexistent.key")
-
-          expect(consoleWarnSpy).toHaveBeenCalled()
-        })
       })
+    })
+  })
+
+  describe("when using the intl object", () => {
+    let mockTranslations: LanguageTranslations
+
+    beforeEach(() => {
+      mockTranslations = {
+        en: {
+          greeting: "Hello!",
+        },
+      }
+    })
+
+    it("should provide access to formatNumber", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      const formatted = result.current.intl.formatNumber(1000)
+
+      expect(formatted).toBe("1,000")
+    })
+
+    it("should provide access to formatDate", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      const date = new Date(Date.UTC(2024, 0, 15))
+      const formatted = result.current.intl.formatDate(date, {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        timeZone: "UTC",
+      })
+
+      expect(formatted).toBe("January 15, 2024")
+    })
+
+    it("should provide access to formatMessage", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      const formatted = result.current.intl.formatMessage({ id: "greeting" })
+
+      expect(formatted).toBe("Hello!")
     })
   })
 

--- a/test/hooks/useTranslation.test.ts
+++ b/test/hooks/useTranslation.test.ts
@@ -1,0 +1,485 @@
+import { act, renderHook } from "@testing-library/react/pure"
+import { useTranslation } from "../../src/hooks/useTranslation"
+import type { LanguageTranslations } from "../../src/hooks/useTranslation"
+
+describe("useTranslation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(console, "warn").mockImplementation()
+    jest.spyOn(console, "error").mockImplementation()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe("when initialized with a locale", () => {
+    let mockTranslations: LanguageTranslations
+
+    beforeEach(() => {
+      mockTranslations = {
+        en: {
+          greeting: "Hello, {name}!",
+          welcome: "Welcome to our app",
+          simple: "Simple text",
+        },
+        es: {
+          greeting: "Hola, {name}!",
+          welcome: "Bienvenido a nuestra aplicación",
+          simple: "Texto simple",
+        },
+      }
+    })
+
+    it("should set the initial locale correctly", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      expect(result.current.locale).toBe("en")
+    })
+
+    it("should initialize with loading set to false", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      expect(result.current.loading).toBe(false)
+    })
+
+    it("should initialize with no error", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      expect(result.current.error).toBe(null)
+    })
+  })
+
+  describe("when translating simple keys", () => {
+    let mockTranslations: LanguageTranslations
+
+    beforeEach(() => {
+      mockTranslations = {
+        en: {
+          simple: "Simple text",
+        },
+      }
+    })
+
+    it("should return the translated text", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      expect(result.current.t("simple")).toBe("Simple text")
+    })
+  })
+
+  describe("when translating with interpolation", () => {
+    describe("and using a single placeholder", () => {
+      let mockTranslations: LanguageTranslations
+
+      beforeEach(() => {
+        mockTranslations = {
+          en: {
+            greeting: "Hello, {name}!",
+          },
+        }
+      })
+
+      it("should interpolate the value correctly", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "en",
+            translations: mockTranslations,
+          })
+        )
+
+        expect(result.current.t("greeting", { name: "John" })).toBe(
+          "Hello, John!"
+        )
+      })
+    })
+
+    describe("and using multiple placeholders", () => {
+      let mockTranslations: LanguageTranslations
+
+      beforeEach(() => {
+        mockTranslations = {
+          en: {
+            message: "Hello {firstName} {lastName}, you have {count} messages",
+          },
+        }
+      })
+
+      it("should interpolate all values correctly", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "en",
+            translations: mockTranslations,
+          })
+        )
+
+        const translation = result.current.t("message", {
+          firstName: "John",
+          lastName: "Doe",
+          count: 5,
+        })
+
+        expect(translation).toBe("Hello John Doe, you have 5 messages")
+      })
+    })
+  })
+
+  describe("when changing locales", () => {
+    let mockTranslations: LanguageTranslations
+
+    beforeEach(() => {
+      mockTranslations = {
+        en: {
+          simple: "Simple text",
+          greeting: "Hello, {name}!",
+        },
+        es: {
+          simple: "Texto simple",
+          greeting: "Hola, {name}!",
+        },
+        fr: {
+          greeting: "Bonjour, {name}!",
+        },
+      }
+    })
+
+    it("should update the locale", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      act(() => {
+        result.current.setLocale("es")
+      })
+
+      expect(result.current.locale).toBe("es")
+    })
+
+    it("should return translations for the new locale", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      act(() => {
+        result.current.setLocale("es")
+      })
+
+      expect(result.current.t("simple")).toBe("Texto simple")
+    })
+
+    it("should handle multiple locale changes correctly", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      expect(result.current.t("greeting", { name: "Alice" })).toBe(
+        "Hello, Alice!"
+      )
+
+      act(() => {
+        result.current.setLocale("es")
+      })
+
+      expect(result.current.t("greeting", { name: "Alice" })).toBe(
+        "Hola, Alice!"
+      )
+
+      act(() => {
+        result.current.setLocale("fr")
+      })
+
+      expect(result.current.t("greeting", { name: "Alice" })).toBe(
+        "Bonjour, Alice!"
+      )
+    })
+  })
+
+  describe("when a translation key is not found", () => {
+    describe("and no fallback locale is configured", () => {
+      let mockTranslations: LanguageTranslations
+      let consoleWarnSpy: jest.SpyInstance
+
+      beforeEach(() => {
+        mockTranslations = {
+          en: {
+            simple: "Simple text",
+          },
+        }
+        consoleWarnSpy = jest.spyOn(console, "warn")
+      })
+
+      it("should return the key itself", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "en",
+            translations: mockTranslations,
+          })
+        )
+
+        const translation = result.current.t("nonexistent.key")
+
+        expect(translation).toBe("nonexistent.key")
+      })
+
+      it("should log a warning with the missing key and locale", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "en",
+            translations: mockTranslations,
+          })
+        )
+
+        result.current.t("nonexistent.key")
+
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          'Translation key "nonexistent.key" not found for locale "en"'
+        )
+      })
+    })
+
+    describe("and a fallback locale is configured", () => {
+      describe("and the key exists in the fallback locale", () => {
+        let mockTranslations: LanguageTranslations
+        let consoleWarnSpy: jest.SpyInstance
+
+        beforeEach(() => {
+          mockTranslations = {
+            en: {
+              welcome: "Welcome to our app",
+            },
+            fr: {
+              greeting: "Bonjour!",
+            },
+          }
+          consoleWarnSpy = jest.spyOn(console, "warn")
+        })
+
+        it("should return the translation from the fallback locale", () => {
+          const { result } = renderHook(() =>
+            useTranslation({
+              locale: "fr",
+              translations: mockTranslations,
+              fallbackLocale: "en",
+            })
+          )
+
+          const translation = result.current.t("welcome")
+
+          expect(translation).toBe("Welcome to our app")
+        })
+
+        it("should log a warning about using the fallback locale", () => {
+          const { result } = renderHook(() =>
+            useTranslation({
+              locale: "fr",
+              translations: mockTranslations,
+              fallbackLocale: "en",
+            })
+          )
+
+          result.current.t("welcome")
+
+          expect(consoleWarnSpy).toHaveBeenCalledWith(
+            'Translation key "welcome" not found for locale "fr", using fallback locale "en"'
+          )
+        })
+      })
+
+      describe("and the key does not exist in the fallback locale", () => {
+        let mockTranslations: LanguageTranslations
+        let consoleWarnSpy: jest.SpyInstance
+
+        beforeEach(() => {
+          mockTranslations = {
+            en: {
+              welcome: "Welcome",
+            },
+            fr: {
+              greeting: "Bonjour!",
+            },
+          }
+          consoleWarnSpy = jest.spyOn(console, "warn")
+        })
+
+        it("should return the key itself", () => {
+          const { result } = renderHook(() =>
+            useTranslation({
+              locale: "fr",
+              translations: mockTranslations,
+              fallbackLocale: "en",
+            })
+          )
+
+          const translation = result.current.t("nonexistent.key")
+
+          expect(translation).toBe("nonexistent.key")
+        })
+
+        it("should log a warning", () => {
+          const { result } = renderHook(() =>
+            useTranslation({
+              locale: "fr",
+              translations: mockTranslations,
+              fallbackLocale: "en",
+            })
+          )
+
+          result.current.t("nonexistent.key")
+
+          expect(consoleWarnSpy).toHaveBeenCalled()
+        })
+      })
+    })
+  })
+
+  describe("when setting an invalid locale", () => {
+    let mockTranslations: LanguageTranslations
+    let consoleErrorSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      mockTranslations = {
+        en: {
+          simple: "Simple text",
+        },
+        es: {
+          simple: "Texto simple",
+        },
+        fr: {
+          simple: "Texte simple",
+        },
+      }
+      consoleErrorSpy = jest.spyOn(console, "error")
+    })
+
+    it("should keep the current locale unchanged", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      act(() => {
+        result.current.setLocale("de")
+      })
+
+      expect(result.current.locale).toBe("en")
+    })
+
+    it("should set an error message", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      act(() => {
+        result.current.setLocale("de")
+      })
+
+      expect(result.current.error).toBe('Locale "de" not found')
+    })
+
+    it("should log an error with available locales", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      act(() => {
+        result.current.setLocale("de")
+      })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Locale "de" not found in translations. Available locales: en, es, fr'
+      )
+    })
+  })
+
+  describe("when setting a valid locale after an invalid one", () => {
+    let mockTranslations: LanguageTranslations
+
+    beforeEach(() => {
+      mockTranslations = {
+        en: {
+          simple: "Simple text",
+        },
+        es: {
+          simple: "Texto simple",
+        },
+      }
+    })
+
+    it("should clear the error", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      act(() => {
+        result.current.setLocale("de")
+      })
+
+      expect(result.current.error).toBe('Locale "de" not found')
+
+      act(() => {
+        result.current.setLocale("es")
+      })
+
+      expect(result.current.error).toBe(null)
+    })
+
+    it("should update to the new valid locale", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      act(() => {
+        result.current.setLocale("de")
+      })
+
+      act(() => {
+        result.current.setLocale("es")
+      })
+
+      expect(result.current.locale).toBe("es")
+    })
+  })
+})

--- a/test/hooks/useTranslation.test.ts
+++ b/test/hooks/useTranslation.test.ts
@@ -760,4 +760,207 @@ describe("useTranslation", () => {
       expect(formatted).toBe("12.34%")
     })
   })
+
+  describe("when using ICU message syntax", () => {
+    describe("and using pluralization", () => {
+      let mockTranslations: LanguageTranslations
+
+      beforeEach(() => {
+        mockTranslations = {
+          en: {
+            items:
+              "{count, plural, =0 {No items} one {# item} other {# items}}",
+          },
+          es: {
+            items:
+              "{count, plural, =0 {Sin elementos} one {# elemento} other {# elementos}}",
+          },
+        }
+      })
+
+      it("should handle zero count", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "en",
+            translations: mockTranslations,
+          })
+        )
+
+        expect(result.current.t("items", { count: 0 })).toBe("No items")
+      })
+
+      it("should handle singular count", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "en",
+            translations: mockTranslations,
+          })
+        )
+
+        expect(result.current.t("items", { count: 1 })).toBe("1 item")
+      })
+
+      it("should handle plural count", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "en",
+            translations: mockTranslations,
+          })
+        )
+
+        expect(result.current.t("items", { count: 5 })).toBe("5 items")
+      })
+
+      it("should handle pluralization in different locales", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "es",
+            translations: mockTranslations,
+          })
+        )
+
+        expect(result.current.t("items", { count: 1 })).toBe("1 elemento")
+        expect(result.current.t("items", { count: 5 })).toBe("5 elementos")
+      })
+    })
+
+    describe("and using select syntax", () => {
+      let mockTranslations: LanguageTranslations
+
+      beforeEach(() => {
+        mockTranslations = {
+          en: {
+            gender: "{gender, select, male {He} female {She} other {They}}",
+          },
+        }
+      })
+
+      it("should handle select with male option", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "en",
+            translations: mockTranslations,
+          })
+        )
+
+        expect(result.current.t("gender", { gender: "male" })).toBe("He")
+      })
+
+      it("should handle select with female option", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "en",
+            translations: mockTranslations,
+          })
+        )
+
+        expect(result.current.t("gender", { gender: "female" })).toBe("She")
+      })
+
+      it("should handle select with other option", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "en",
+            translations: mockTranslations,
+          })
+        )
+
+        expect(result.current.t("gender", { gender: "unknown" })).toBe("They")
+      })
+    })
+
+    describe("and using complex ICU syntax", () => {
+      let mockTranslations: LanguageTranslations
+
+      beforeEach(() => {
+        mockTranslations = {
+          en: {
+            notification:
+              "{count, plural, =0 {No notifications} =1 {You have one notification} other {You have # notifications}}",
+          },
+        }
+      })
+
+      it("should handle complex plural with specific values", () => {
+        const { result } = renderHook(() =>
+          useTranslation({
+            locale: "en",
+            translations: mockTranslations,
+          })
+        )
+
+        expect(result.current.t("notification", { count: 0 })).toBe(
+          "No notifications"
+        )
+        expect(result.current.t("notification", { count: 1 })).toBe(
+          "You have one notification"
+        )
+        expect(result.current.t("notification", { count: 5 })).toBe(
+          "You have 5 notifications"
+        )
+      })
+    })
+  })
+
+  describe("when using additional intl formatting functions", () => {
+    let mockTranslations: LanguageTranslations
+
+    beforeEach(() => {
+      mockTranslations = {
+        en: {
+          greeting: "Hello!",
+        },
+      }
+    })
+
+    it("should format lists", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      const formatted = result.current.intl.formatList([
+        "apple",
+        "banana",
+        "orange",
+      ])
+
+      expect([
+        "apple, banana, and orange",
+        "apple, banana, and orange",
+      ]).toContain(formatted)
+    })
+
+    it("should format display names for languages", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      const formatted = result.current.intl.formatDisplayName("es", {
+        type: "language",
+      })
+
+      expect(formatted).toBe("Spanish")
+    })
+
+    it("should format display names for countries", () => {
+      const { result } = renderHook(() =>
+        useTranslation({
+          locale: "en",
+          translations: mockTranslations,
+        })
+      )
+
+      const formatted = result.current.intl.formatDisplayName("US", {
+        type: "region",
+      })
+
+      expect(["United States", "US"]).toContain(formatted)
+    })
+  })
 })

--- a/test/hooks/useTranslation.test.ts
+++ b/test/hooks/useTranslation.test.ts
@@ -42,17 +42,6 @@ describe("useTranslation", () => {
       expect(result.current.locale).toBe("en")
     })
 
-    it("should initialize with loading set to false", () => {
-      const { result } = renderHook(() =>
-        useTranslation({
-          locale: "en",
-          translations: mockTranslations,
-        })
-      )
-
-      expect(result.current.loading).toBe(false)
-    })
-
     it("should initialize with no error", () => {
       const { result } = renderHook(() =>
         useTranslation({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "baseUrl": "src",
     "outDir": "dist",
     "declaration": true,


### PR DESCRIPTION
This PR introduces a new `useTranslation` hook that provides lightweight translation management, adds i18n hook powered by react-intl.

  Features:
  - Dynamic locale switching
  - String interpolation with placeholders (e.g., `{name}`)
  - Fallback locale support for missing translations
  - Configurable per project - languages are passed as parameters
  - Number/date/currency formatting via intl object
  - ICU message syntax (pluralization, select)
  - Advanced intl formatting functions