### PR TITLE
feat: add useNotifications hook and notifications client

### DIFF
--- a/.cursor/rules/hooks-testing.mdc
+++ b/.cursor/rules/hooks-testing.mdc
@@ -1,230 +1,67 @@
 ---
-description: 
-globs: 
+description: "Testing standards for custom hooks in this repository."
+globs: test/hooks/**/*.test.ts,test/hooks/**/*.test.tsx
 alwaysApply: true
 ---
 # Testing Standards for Custom Hooks
 
-## Language and Documentation
+## Language
+- Tests, descriptions, and mock data must be in English.
+- `it` descriptions follow: "should [expected behavior] when [condition]".
+- No JSDoc in test files. Comments only if required for complex logic.
 
-### Test Language
-- All test files must be written in English
-- Test descriptions must follow the pattern: "should [expected behavior] when [condition]"
-- Error messages and mock data must be in English
-- No inline comments in test files unless absolutely necessary for complex logic
-- No JSDoc comments in test files
+## Location and Naming
+- Tests live in `test/hooks/`.
+- File name: `[hook-name].test.ts` or `[hook-name].test.tsx`.
 
-## Directory Structure
+## Structure
+- Use `describe` for contexts and `it` for behaviors.
+- Use `beforeEach` for setup and `afterEach` for cleanup.
+- Use `renderHook` and wrap state changes with `act`.
 
-### Test Organization
-- Unit tests must be placed in `test/hooks/`
-- Test utilities and mocks in `test/__mocks__/`
-- Test types in `test/types/`
-- NEVER place test files alongside source files
-
-### File Naming
-- Test files: `[hook-name].test.ts`
-- Mock files: `[mock-name].ts`
-- Test utility files: `[utility-name].ts`
-
-## Test Structure
-
-### Basic Structure
 ```typescript
 import { act, renderHook } from "@testing-library/react/pure"
 import { useHook } from "../../src/hooks/useHook"
-
-jest.mock("../__mocks__/sentry") // Si es necesario
 
 describe("useHook", () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
-  describe("when [initial state]", () => {
-    it("should [expected behavior]", () => {
-      const { result } = renderHook(() => useHook())
-      expect(result.current).toEqual(expectedValue)
+  it("should return initial state when initialized", () => {
+    const { result } = renderHook(() => useHook())
+    expect(result.current).toEqual(expectedValue)
+  })
+
+  it("should update state when action is called", () => {
+    const { result } = renderHook(() => useHook())
+
+    act(() => {
+      // perform action
     })
-  })
 
-  describe("when [action]", () => {
-    it("should [expected behavior]", async () => {
-      const { result } = renderHook(() => useHook())
-      
-      act(() => {
-        // Perform action
-      })
-
-      expect(result.current).toEqual(expectedValue)
-    })
-  })
-
-  describe("when [error condition]", () => {
-    it("should [handle error]", async () => {
-      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation()
-      // Test implementation
-      consoleErrorSpy.mockRestore()
-    })
+    expect(result.current).toEqual(expectedValue)
   })
 })
 ```
 
-### Async Hook Testing
-```typescript
-describe("useAsyncHook", () => {
-  it("should handle loading state", async () => {
-    const { result } = renderHook(() => useAsyncHook())
-    expect(result.current.loading).toBe(true)
-    await new Promise((resolve) => setTimeout(resolve, 100))
-    expect(result.current.loading).toBe(false)
-  })
+## Async Testing
+- Test loading, success, and error states.
+- Clean up async operations and mocks.
+- Avoid fixed timeouts when possible; prefer explicit waits for state changes.
 
-  it("should handle success state", async () => {
-    const mockData = { test: "data" }
-    const mockCallback = jest.fn().mockResolvedValue(mockData)
-    const { result } = renderHook(() => useAsyncHook(mockCallback))
-    
-    await new Promise((resolve) => setTimeout(resolve, 100))
-    expect(result.current.data).toEqual(mockData)
-  })
+## Mocking
+- Use `jest.fn()` and verify calls.
+- Reset and restore mocks in `afterEach`.
 
-  it("should handle error state", async () => {
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation()
-    const mockError = new Error("Test error")
-    const mockCallback = jest.fn().mockRejectedValue(mockError)
-    const { result } = renderHook(() => useAsyncHook(mockCallback))
-    
-    await new Promise((resolve) => setTimeout(resolve, 100))
-    expect(result.current.error).toBe(mockError)
-    consoleErrorSpy.mockRestore()
-  })
-})
-```
-
-## Testing Patterns
-
-### State Management
-- Test initial state
-- Test state updates
-- Test state persistence
-- Test state cleanup
-
-### Async Operations
-- Test loading states
-- Test success states
-- Test error states
-- Test cancellation
-- Test cleanup
-
-### Dependencies
-- Test dependency changes
-- Test dependency cleanup
-- Test memoization
-
-### Error Handling
-- Test error states
-- Test error recovery
-- Test error logging
-- Test error boundaries
-
-## Mocking Guidelines
-
-### Mock Setup
-```typescript
-const mockCallback = jest.fn().mockResolvedValue(mockData)
-const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation()
-
-beforeEach(() => {
-  jest.clearAllMocks()
-})
-
-afterEach(() => {
-  consoleErrorSpy.mockRestore()
-})
-```
-
-### Mock Verification
-```typescript
-expect(mockCallback).toHaveBeenCalledWith(expectedArgs)
-expect(mockCallback).toHaveBeenCalledTimes(expectedCalls)
-expect(consoleErrorSpy).toHaveBeenCalledWith(expectedError)
-```
-
-## Test Coverage Requirements
-
-### Required Test Cases
-1. Initial state
-2. State updates
-3. Async operations
-4. Error handling
-5. Cleanup
-6. Dependencies
-7. Edge cases
-
-### Coverage Thresholds
+## Coverage Thresholds
 - Statements: 90%
 - Branches: 85%
 - Functions: 90%
 - Lines: 90%
 
-## Best Practices
-
-### Test Organization
-- Group related tests using `describe` blocks
-- Use clear, descriptive test names
-- Follow the pattern: "should [expected behavior] when [condition]"
-- Keep tests focused and atomic
-
-### Async Testing
-- Use `act` for state updates
-- Handle promises properly
-- Clean up async operations
-- Test loading states
-- Test error states
-
-### Error Handling
-- Mock console.error
-- Test error states
-- Verify error messages
-- Clean up error mocks
-
-### Cleanup
-- Reset mocks after each test
-- Clean up async operations
-- Restore console mocks
-- Unmount hooks when needed
-
-## Anti-patterns to Avoid
-
-1. **Test Structure**
-   - ❌ Large test files without clear organization
-   - ❌ Missing setup/teardown
-   - ❌ Not cleaning up mocks
-   - ❌ Not handling async operations properly
-
-2. **Test Quality**
-   - ❌ Testing implementation details
-   - ❌ Not testing error cases
-   - ❌ Inconsistent naming
-   - ❌ Missing assertions
-   - ❌ Not verifying mock calls
-
-3. **Async Testing**
-   - ❌ Not using `act`
-   - ❌ Not handling promises
-   - ❌ Not cleaning up async operations
-   - ❌ Not testing loading states
-
-4. **Mocking**
-   - ❌ Not resetting mocks
-   - ❌ Not verifying mock calls
-   - ❌ Not cleaning up mocks
-   - ❌ Mocking too much or too little
-
-5. **Error Handling**
-   - ❌ Not mocking console.error
-   - ❌ Not testing error states
-   - ❌ Not verifying error messages
-   - ❌ Not cleaning up error mocks
-
+## Anti-patterns
+- Testing implementation details instead of behavior.
+- Missing assertions.
+- Not cleaning up mocks or async effects.
+- Inconsistent test naming.

--- a/.cursor/rules/hooks.mdc
+++ b/.cursor/rules/hooks.mdc
@@ -1,353 +1,87 @@
 ---
-description: 
-globs: 
+description: "Standards for implementing and exporting custom hooks in this repository."
+globs: src/hooks/**/*.ts,src/hooks/**/*.tsx
 alwaysApply: true
 ---
 # Custom Hooks Development Standards
 
-## File Structure
+## Scope
+These standards apply to all custom hooks under `src/hooks/`.
 
-### File Organization
+## File Layout (recommended order)
+1. Imports
+2. Types and interfaces
+3. Hook implementation
+4. Exports
+
 ```typescript
-// 1. Imports (ordered)
-import {} from /* core dependencies */ "core"
-import {} from /* utilities */ "../utils"
+import { useCallback, useMemo, useState } from "react"
 
-// 2. Types and Interfaces
-type HookState<T> = {
-  // State definition
-}
-
-type HookOptions = {
-  // Hook options
-}
-
-// 3. Hook Implementation
-/**
- * Hook description
- * @param param1 - Parameter description
- * @returns Return value description
- */
-const useHook = <T>(param1: T, options?: HookOptions) => {
-  // Implementation
-}
-
-// 4. Exports
-export { useHook }
-export type { HookState, HookOptions }
-```
-
-### File Naming
-- Use PascalCase for hook files: `useHook.ts`
-- Use camelCase for utility files: `utils.ts`
-- Index files should be lowercase: `index.ts`
-
-## Type System
-
-### Generic Types
-```typescript
-// ✅ Good
-const useHook = <T, I = null>(
-  callback: () => Promise<T>,
-  options?: HookOptions<T, I>
-) => {
-  // Implementation
-}
-
-// ❌ Bad
-const useHook = (callback: () => Promise<any>) => {
-  // Implementation
-}
-```
-
-### Type Definitions
-```typescript
-// State types should be explicit
 type HookState<T> = {
   data: T | null
   loading: boolean
   error: Error | null
-  version: number
 }
 
-// Options should be partial and documented
-type HookOptions = {
+type HookOptions<T> = {
   initialValue?: T
   onError?: (error: Error) => void
-  // Add framework-specific options as needed
 }
+
+const useThing = <T>(options?: HookOptions<T>) => {
+  const [state, setState] = useState<HookState<T>>({
+    data: null,
+    loading: false,
+    error: null,
+  })
+
+  const setLoading = useCallback(() => {
+    setState((prev) => ({ ...prev, loading: true }))
+  }, [])
+
+  const value = useMemo(() => state.data, [state.data])
+
+  return { ...state, value, setLoading }
+}
+
+export { useThing }
+export type { HookState, HookOptions }
 ```
+
+## Types
+- Prefer explicit types; avoid `any`.
+- Use generics for data and results.
+- Name types with `State`, `Options`, `Result` suffixes.
 
 ## State Management
+- Prefer a single state object for related values.
+- Use functional updates (`setState((prev) => ...)`).
 
-### State Initialization
-```typescript
-// ✅ Good
-const [state, setState] = useState<HookState<T>>({
-  data: null,
-  loading: false,
-  error: null,
-  version: 0,
-})
+## Async Effects
+- Guard against updates after unmount (cancellation flag).
+- Normalize unknown errors to `Error` before storing.
 
-// ❌ Bad
-const [data, setData] = useState(null)
-const [loading, setLoading] = useState(false)
-```
+## Performance
+- Use `useCallback` for stable handlers.
+- Use `useMemo` for expensive derived values.
+- Dependency arrays must be complete.
 
-### State Updates
-```typescript
-// ✅ Good
-setState((prev) => ({
-  ...prev,
-  loading: true,
-  version: prev.version + 1,
-}))
-
-// ❌ Bad
-setState({
-  ...state,
-  loading: true,
-})
-```
-
-## Performance Optimizations
-
-### Function Memoization
-```typescript
-// ✅ Good
-const handler = useCallback(
-  (value: T) => {
-    // Implementation
-  },
-  [
-    /* dependencies */
-  ]
-)
-
-// ❌ Bad
-const handler = (value: T) => {
-  // Implementation
-}
-```
-
-### Value Memoization
-```typescript
-// ✅ Good
-const memoizedValue = useMemo(() => {
-  return expensiveComputation(value)
-}, [value])
-
-// ❌ Bad
-const value = expensiveComputation(props.value)
-```
-
-## Async Operations
-
-### Async Effect Pattern
-```typescript
-useEffect(
-  () => {
-    let cancelled = false
-
-    const asyncOperation = async () => {
-      try {
-        setState((prev) => ({ ...prev, loading: true }))
-        const result = await operation()
-
-        if (cancelled) return
-
-        setState((prev) => ({
-          ...prev,
-          data: result,
-          loading: false,
-        }))
-      } catch (error) {
-        if (cancelled) return
-
-        setState((prev) => ({
-          ...prev,
-          error: error instanceof Error ? error : new Error("Unknown error"),
-          loading: false,
-        }))
-      }
-    }
-
-    asyncOperation()
-
-    return () => {
-      cancelled = true
-    }
-  },
-  [
-    /* dependencies */
-  ]
-)
-```
-
-### Promise Handling
-```typescript
-// ✅ Good
-Promise.resolve()
-  .then(() => operation())
-  .then((result) => {
-    if (cancelled) return
-    // Handle success
-  })
-  .catch((error) => {
-    if (cancelled) return
-    // Handle error
-  })
-
-// ❌ Bad
-operation()
-  .then((result) => {
-    // Handle success
-  })
-  .catch((error) => {
-    // Handle error
-  })
-```
-
-## Error Handling
-
-### Error Management
-```typescript
-try {
-  // Operation
-} catch (error) {
-  console.error(error)
-  // Use your preferred error tracking service
-  errorTracker.captureException(error)
-
-  setState((prev) => ({
-    ...prev,
-    error: error instanceof Error ? error : new Error("Unknown error"),
-    loading: false,
-  }))
-}
-```
-
-### Error Types
-```typescript
-type HookError = {
-  code: string
-  message: string
-  details?: unknown
-}
-
-const handleError = (error: unknown): HookError => {
-  if (error instanceof Error) {
-    return {
-      code: "UNKNOWN_ERROR",
-      message: error.message,
-    }
-  }
-  return {
-    code: "UNKNOWN_ERROR",
-    message: "An unknown error occurred",
-  }
-}
-```
-
-## Naming Conventions
-
-### Hook Names
-- Prefix all hooks with `use`: `useAsyncState`, `usePatchState`
-- Use descriptive names that indicate functionality
-- Avoid abbreviations unless widely understood
-- Framework-specific hooks should indicate their framework: `useReactHook`, `useVueHook`
-
-### Type Names
-- Suffix state types with `State`: `HookState`
-- Suffix option types with `Options`: `HookOptions`
-- Suffix result types with `Result`: `HookResult`
-- Framework-specific types should indicate their framework: `ReactHookState`, `VueHookState`
-
-### Variable Names
-- Use camelCase for variables and functions
-- Use PascalCase for types and interfaces
-- Use UPPER_CASE for constants
-- Framework-specific variables should indicate their framework: `reactState`, `vueState`
+## Naming
+- Hooks must start with `use`.
+- Types: PascalCase. Variables/functions: camelCase. Constants: UPPER_CASE.
 
 ## Documentation
-
-### JSDoc Comments
-```typescript
-/**
- * Hook description
- *
- * @template T - Type of the data being managed
- * @param callback - Async function to execute
- * @param deps - Dependencies array
- * @param options - Optional configuration
- * @returns Tuple containing [state, actions]
- *
- * @example
- * ```ts
- * const [state, actions] = useHook(async () => {
- *   return await fetchData()
- * })
- * ```
- * 
- * @framework React/Vue/etc
- * @version 1.0.0
- */
-```
-
-### Inline Documentation
-```typescript
-// Document complex logic
-const processData = (data: T) => {
-  // Step 1: Validate input
-  if (!isValid(data)) {
-    throw new Error("Invalid data")
-  }
-
-  // Step 2: Transform data
-  const transformed = transform(data)
-
-  // Step 3: Return result
-  return transformed
-}
-```
+- Public hooks require JSDoc with `@param` and `@returns`.
+- Keep examples short and focused.
 
 ## Exports
+- Use named exports only.
+- Export the hook and all public types.
+- Re-export from `src/hooks/index.ts`.
 
-### Index File Structure
-```typescript
-// Types
-export type { HookState, HookOptions } from "./useHook"
-
-// Hooks
-export { useHook } from "./useHook"
-
-// Utilities
-export { createHookState } from "./utils"
-
-// Framework-specific exports
-export { useReactHook } from "./react/useHook"
-export { useVueHook } from "./vue/useHook"
-```
-
-### Export Rules
-- Export all public types
-- Export all hooks
-- Export utility functions that are part of the public API
-- Use named exports instead of default exports
-- Group framework-specific exports in subdirectories
-- Include framework information in exports when relevant
-
-
-## Code Review Checklist
-- [ ] Follows hook rules
-- [ ] Properly typed
-- [ ] Well documented
-- [ ] Includes tests
-- [ ] Handles errors
-- [ ] Performance considered
-- [ ] Security considered
-- [ ] Accessibility considered
-- [ ] Framework compatibility considered
-- [ ] Cross-framework testing when applicable
-
+## Review Checklist (short)
+- Types are explicit and correct.
+- Errors are handled and normalized.
+- Tests exist for behavior.
+- Performance and deps are considered.
+- Docs are present for public hooks.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ npm install @dcl/hooks
 - `useAsyncMemo`: Async version of useMemo
 - `useInfiniteScroll`: Infinite scroll functionality for loading more content
 - `useTranslation`: Simple and lightweight translation management
+- `useNotifications`: Notification polling and modal state management
 
 ## Examples
 
@@ -701,6 +702,100 @@ function MyComponent() {
     </div>
   )
 }
+```
+
+### useNotifications
+
+The `useNotifications` hook manages notification polling, modal state, and onboarding flow. It uses Decentraland's notifications API by default.
+
+Basic usage:
+
+```typescript
+import { useNotifications } from '@dcl/hooks'
+import type { AuthIdentity } from 'decentraland-crypto-fetch'
+
+function NotificationsComponent() {
+  const identity: AuthIdentity = useAuthIdentity() // From your auth context
+
+  const {
+    notifications,
+    isLoading,
+    isModalOpen,
+    isNotificationsOnboarding,
+    handleNotificationsOpen,
+    handleOnBegin
+  } = useNotifications({
+    identity,
+    isNotificationsEnabled: !!identity,
+    notificationsUrl: 'https://notifications.decentraland.org' // or .zone for dev
+  })
+
+  if (isNotificationsOnboarding) {
+    return (
+      <div>
+        <h2>Welcome to Notifications!</h2>
+        <button onClick={handleOnBegin}>Get Started</button>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <button onClick={handleNotificationsOpen}>
+        Notifications ({notifications.filter(n => !n.read).length})
+      </button>
+
+      {isModalOpen && (
+        <ul>
+          {notifications.map(notification => (
+            <li key={notification.id}>
+              {notification.type} - {notification.read ? 'Read' : 'Unread'}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+```
+
+With custom polling interval:
+
+```typescript
+const { notifications } = useNotifications({
+  identity,
+  isNotificationsEnabled: !!identity,
+  notificationsUrl: 'https://notifications.decentraland.org',
+  queryIntervalMs: 30000 // Poll every 30 seconds (default: 60000)
+})
+```
+
+With notification type filtering:
+
+```typescript
+const { notifications } = useNotifications({
+  identity,
+  isNotificationsEnabled: !!identity,
+  notificationsUrl: 'https://notifications.decentraland.org',
+  availableNotificationTypes: ['bid', 'sale', 'royalties']
+})
+```
+
+With error handling:
+
+`onError` is called when fetching fails, marking as read fails, or when
+`notificationsUrl` is missing.
+
+```typescript
+const { notifications } = useNotifications({
+  identity,
+  isNotificationsEnabled: !!identity,
+  notificationsUrl: 'https://notifications.decentraland.org',
+  onError: (error) => {
+    console.error('Notification error:', error)
+    Sentry.captureException(error)
+  }
+})
 ```
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/ua-parser-js": "^0.7.39",
         "@typescript-eslint/eslint-plugin": "^7.15.0",
         "@typescript-eslint/parser": "^7.15.0",
+        "decentraland-crypto-fetch": "^2.0.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-import-resolver-jest": "^3.0.2",
@@ -42,6 +43,7 @@
         "typescript-eslint": "^7.15.0"
       },
       "peerDependencies": {
+        "decentraland-crypto-fetch": "^2.0.1",
         "react": "^18.0.0"
       }
     },
@@ -523,6 +525,18 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@dcl/crypto": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.5.tgz",
+      "integrity": "sha512-uneyjOAOx7pi5kabZsLmPm9kSLkCk4Cok8FUsvT+6k8RquqkjKqocvkGVOMaoWsfU6S3mkLOyaeqEKmOy4ErxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@dcl/schemas": "^9.2.0",
+        "eth-connect": "^6.0.3",
+        "ethereum-cryptography": "^1.0.3"
+      }
+    },
     "node_modules/@dcl/eslint-config": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@dcl/eslint-config/-/eslint-config-2.2.1.tgz",
@@ -778,6 +792,65 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@dcl/schemas": {
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-9.15.0.tgz",
+      "integrity": "sha512-nip5rsOcJplNfBWeImwezuHLprM0gLW03kEeqGIvT9J6HnEBTtvIwkk9+NSt7hzFKEvWGI+C23vyNWbG3nU+SQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0"
+      }
+    },
+    "node_modules/@dcl/schemas/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@dcl/schemas/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/@dcl/schemas/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/@dcl/schemas/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
@@ -1546,6 +1619,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1607,6 +1706,51 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
+      "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.2.0",
+        "@noble/secp256k1": "~1.7.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
+      "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.2.0",
+        "@scure/base": "~1.1.0"
+      }
     },
     "node_modules/@segment/analytics-core": {
       "version": "1.8.1",
@@ -3008,6 +3152,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/core-js-pure": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
+      "integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -3187,6 +3343,21 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decentraland-crypto-fetch": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/decentraland-crypto-fetch/-/decentraland-crypto-fetch-2.0.1.tgz",
+      "integrity": "sha512-2IKu6Y4k/fle8bmU0b4zy7V1i1R0oCXtqlJumBXc4jwHUHKAcHDLD2YtgJFdd7JjsWQwf+t0DsKpzBCjQDKANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@dcl/crypto": "^3.3.1",
+        "core-js-pure": "^3.19.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
       }
     },
     "node_modules/decimal.js": {
@@ -4265,6 +4436,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eth-connect": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/eth-connect/-/eth-connect-6.2.4.tgz",
+      "integrity": "sha512-K0+g+pZoWkcJKKc4hwlYvaruoMBFcARoULIdf50bz/Zk9YdgFoKPjlRQWAtBgSDfxJS7AAHqg40k2Z/uQI0aNw==",
+      "dev": true,
+      "license": "LGPL-3.0"
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
+      "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.2.0",
+        "@noble/secp256k1": "1.7.1",
+        "@scure/bip32": "1.1.5",
+        "@scure/bip39": "1.1.1"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -4364,6 +4555,23 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.0",
@@ -7885,6 +8093,16 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:coverage": "npm run test -- --coverage"
   },
   "peerDependencies": {
+    "decentraland-crypto-fetch": "^2.0.1",
     "react": "^18.0.0"
   },
   "devDependencies": {
@@ -30,6 +31,7 @@
     "@types/ua-parser-js": "^0.7.39",
     "@typescript-eslint/eslint-plugin": "^7.15.0",
     "@typescript-eslint/parser": "^7.15.0",
+    "decentraland-crypto-fetch": "^2.0.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-jest": "^3.0.2",

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,0 +1,2 @@
+export { createNotificationsClient } from "./notifications"
+export type { NotificationsClientOptions } from "./notifications"

--- a/src/clients/notifications/createNotificationsClient.ts
+++ b/src/clients/notifications/createNotificationsClient.ts
@@ -1,0 +1,90 @@
+import {
+  type AuthIdentity,
+  signedFetchFactory,
+} from "decentraland-crypto-fetch"
+import type {
+  NotificationItem,
+  NotificationsClient,
+} from "../../hooks/useNotifications"
+
+const DEFAULT_NOTIFICATIONS_LIMIT = 50
+
+type NotificationsClientOptions = {
+  url: string
+  limit?: number
+}
+
+type NotificationResponse = NotificationItem & {
+  timestamp: number | string
+}
+
+const parseNotification = (
+  notification: NotificationResponse
+): NotificationItem => ({
+  ...notification,
+  timestamp: Number(notification.timestamp),
+})
+
+/**
+ * Creates a Decentraland notifications client.
+ *
+ * @param identity - The AuthIdentity for signing requests
+ * @param options - Configuration with required url
+ * @returns A NotificationsClient instance
+ */
+const createNotificationsClient = (
+  identity: unknown,
+  options: NotificationsClientOptions
+): NotificationsClient => {
+  const authIdentity = identity as AuthIdentity
+  const { url: baseUrl, limit = DEFAULT_NOTIFICATIONS_LIMIT } = options
+  const signedFetch = signedFetchFactory()
+
+  const getNotifications = async (): Promise<NotificationItem[]> => {
+    const params = new URLSearchParams()
+    params.append("limit", String(limit))
+
+    const url = `${baseUrl}/notifications?${params.toString()}`
+    const response = await signedFetch(url, {
+      identity: authIdentity,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch notifications: ${response.status}`)
+    }
+
+    const data = await response.json()
+    const notifications: NotificationResponse[] = data.notifications ?? []
+
+    return notifications.map(parseNotification)
+  }
+
+  const markNotificationsAsRead = async (ids: string[]): Promise<void> => {
+    const url = `${baseUrl}/notifications/read`
+    const response = await signedFetch(url, {
+      method: "PUT",
+      identity: authIdentity,
+      body: JSON.stringify({ notificationIds: ids }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to mark notifications as read: ${response.status}`
+      )
+    }
+  }
+
+  return {
+    getNotifications,
+    markNotificationsAsRead,
+  }
+}
+
+export { createNotificationsClient }
+export type { NotificationsClientOptions }

--- a/src/clients/notifications/index.ts
+++ b/src/clients/notifications/index.ts
@@ -1,0 +1,2 @@
+export { createNotificationsClient } from "./createNotificationsClient"
+export type { NotificationsClientOptions } from "./createNotificationsClient"

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,6 +4,14 @@ export type { AsyncMemoResult, AsyncMemoResultState } from "./useAsyncMemo"
 export type { AsyncStateResult, AsyncStateResultState } from "./useAsyncState"
 export type { UseInfiniteScrollOptions } from "./useInfiniteScroll"
 export type {
+  NotificationItem,
+  NotificationsClient,
+  NotificationsState,
+  NotificationsUIState,
+  UseNotificationsOptions,
+  UseNotificationsResult,
+} from "./useNotifications"
+export type {
   Translations,
   LanguageTranslations,
   TranslationState,
@@ -20,6 +28,11 @@ export { useAsyncState, createAsyncStateState } from "./useAsyncState"
 export { useAsyncTask } from "./useAsyncTask"
 export { useAsyncTasks } from "./useAsyncTasks"
 export { useInfiniteScroll } from "./useInfiniteScroll"
+export {
+  checkIsOnboarding,
+  setOnboardingDone,
+  useNotifications,
+} from "./useNotifications"
 export { usePageTracking } from "./usePageTracking"
 export { usePatchState } from "./usePatchState"
 export { useTranslation } from "./useTranslation"

--- a/src/hooks/useNotifications/index.ts
+++ b/src/hooks/useNotifications/index.ts
@@ -1,0 +1,14 @@
+export {
+  checkIsOnboarding,
+  setOnboardingDone,
+  useNotifications,
+} from "./useNotifications"
+export { NotificationActiveTab } from "./useNotifications.type"
+export type {
+  NotificationItem,
+  NotificationsClient,
+  NotificationsState,
+  NotificationsUIState,
+  UseNotificationsOptions,
+  UseNotificationsResult,
+} from "./useNotifications.type"

--- a/src/hooks/useNotifications/useNotifications.ts
+++ b/src/hooks/useNotifications/useNotifications.ts
@@ -1,0 +1,285 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  NotificationActiveTab,
+  NotificationItem,
+  NotificationsClient,
+  NotificationsState,
+  NotificationsUIState,
+  UseNotificationsOptions,
+  UseNotificationsResult,
+} from "./useNotifications.type"
+import { createNotificationsClient } from "../../clients/notifications"
+import { getStorageItem, setStorageItem } from "../../utils/storage"
+
+const DEFAULT_QUERY_INTERVAL_MS = 60000
+const ONBOARDING_KEY = "dcl_notifications_onboarding"
+
+const checkIsOnboarding = (): boolean => {
+  const value = getStorageItem<boolean | null>(ONBOARDING_KEY, null)
+  if (value === null) {
+    setStorageItem(ONBOARDING_KEY, true)
+    return true
+  }
+  return value
+}
+
+const setOnboardingDone = (): void => {
+  setStorageItem(ONBOARDING_KEY, false)
+}
+
+/**
+ * Hook to manage notification polling and modal state.
+ * Uses Decentraland's notifications API.
+ *
+ * @param options - Configuration options for notifications polling and UI state.
+ * @returns Notifications state, modal state, and handlers.
+ */
+const useNotifications = (
+  options: UseNotificationsOptions
+): UseNotificationsResult => {
+  const {
+    identity,
+    isNotificationsEnabled,
+    notificationsUrl,
+    availableNotificationTypes,
+    queryIntervalMs = DEFAULT_QUERY_INTERVAL_MS,
+    initialActiveTab = NotificationActiveTab.NEWEST,
+    onError,
+    renderProfile,
+  } = options
+
+  const [notificationsState, setNotificationsState] =
+    useState<NotificationsState>({
+      isLoading: false,
+      notifications: [],
+    })
+  const [uiState, setUiState] = useState<NotificationsUIState>(() => ({
+    activeTab: initialActiveTab,
+    isOnboarding: checkIsOnboarding(),
+    isOpen: false,
+  }))
+  const [notificationsClient, setNotificationsClient] =
+    useState<NotificationsClient | null>(null)
+
+  const notificationsRef = useRef<NotificationItem[]>([])
+  const notificationsClientRef = useRef<NotificationsClient | null>(null)
+
+  useEffect(() => {
+    notificationsRef.current = notificationsState.notifications
+  }, [notificationsState.notifications])
+
+  useEffect(() => {
+    notificationsClientRef.current = notificationsClient
+  }, [notificationsClient])
+
+  const availableNotifications = useMemo(() => {
+    if (!availableNotificationTypes) {
+      return null
+    }
+
+    return new Set(availableNotificationTypes)
+  }, [availableNotificationTypes])
+
+  const fetchAndUpdateNotifications = useCallback(
+    (client: NotificationsClient) => {
+      return Promise.resolve()
+        .then(() => client.getNotifications())
+        .then((notificationsFetched) => {
+          const filteredNotifications = availableNotifications
+            ? notificationsFetched.filter((notification) =>
+                availableNotifications.has(notification.type)
+              )
+            : notificationsFetched
+          const hasReadNotifications = filteredNotifications.some(
+            (notification) => notification.read
+          )
+
+          setNotificationsState((prevState) => ({
+            ...prevState,
+            isLoading: false,
+            notifications: filteredNotifications,
+          }))
+          if (hasReadNotifications) {
+            setOnboardingDone()
+            setUiState((prevState) =>
+              prevState.isOnboarding
+                ? { ...prevState, isOnboarding: false }
+                : prevState
+            )
+          }
+        })
+        .catch((error) => {
+          const normalizedError =
+            error instanceof Error ? error : new Error("Unknown error")
+          console.error("Error fetching notifications:", normalizedError)
+          if (onError) {
+            onError(normalizedError)
+          }
+          setNotificationsState((prevState) => ({
+            ...prevState,
+            isLoading: false,
+          }))
+        })
+    },
+    [availableNotifications, onError]
+  )
+
+  useEffect(() => {
+    if (!identity) {
+      setNotificationsClient(null)
+      return
+    }
+
+    if (!notificationsUrl) {
+      const normalizedError = new Error("notificationsUrl is required")
+      console.error("Notifications URL missing:", normalizedError)
+      if (onError) {
+        onError(normalizedError)
+      }
+      setNotificationsClient(null)
+      return
+    }
+
+    const client = createNotificationsClient(identity, {
+      url: notificationsUrl,
+    })
+    setNotificationsClient(client)
+
+    if (!isNotificationsEnabled) {
+      return
+    }
+
+    let cancelled = false
+    setNotificationsState((prevState) => ({
+      ...prevState,
+      isLoading: true,
+    }))
+
+    const pollNotifications = () => {
+      if (cancelled) {
+        return
+      }
+
+      fetchAndUpdateNotifications(client)
+    }
+
+    pollNotifications()
+
+    const intervalId = setInterval(pollNotifications, queryIntervalMs)
+
+    return () => {
+      cancelled = true
+      clearInterval(intervalId)
+    }
+  }, [
+    identity,
+    isNotificationsEnabled,
+    notificationsUrl,
+    onError,
+    fetchAndUpdateNotifications,
+    queryIntervalMs,
+  ])
+
+  useEffect(() => {
+    const isClosing = !uiState.isOpen
+    if (!isClosing) {
+      return
+    }
+
+    const currentNotifications = notificationsRef.current
+    const currentClient = notificationsClientRef.current
+    if (!currentClient) {
+      return
+    }
+
+    const unreadNotificationsIds = currentNotifications
+      .filter((notification) => !notification.read)
+      .map((notification) => notification.id)
+
+    if (unreadNotificationsIds.length === 0) {
+      return
+    }
+
+    let cancelled = false
+    Promise.resolve()
+      .then(() => currentClient.markNotificationsAsRead(unreadNotificationsIds))
+      .then(() => {
+        if (cancelled) {
+          return
+        }
+
+        setNotificationsState((prevState) => ({
+          ...prevState,
+          notifications: prevState.notifications.map((notification) => ({
+            ...notification,
+            read: unreadNotificationsIds.includes(notification.id)
+              ? true
+              : notification.read,
+          })),
+        }))
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return
+        }
+
+        const normalizedError =
+          error instanceof Error ? error : new Error("Unknown error")
+        console.error("Error marking notifications as read:", normalizedError)
+        if (onError) {
+          onError(normalizedError)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [uiState.isOpen, onError])
+
+  const handleOnBegin = useCallback(() => {
+    setOnboardingDone()
+    setUiState((prevState) => ({
+      ...prevState,
+      isOnboarding: false,
+    }))
+  }, [])
+
+  const handleNotificationsOpen = useCallback(() => {
+    setUiState((prevState) => ({
+      ...prevState,
+      isOpen: !prevState.isOpen,
+    }))
+  }, [])
+
+  const handleOnChangeModalTab = useCallback((tab: string) => {
+    setUiState((prevState) => ({
+      ...prevState,
+      activeTab: tab,
+    }))
+  }, [])
+
+  const handleRenderProfile = useCallback(
+    (address: string) => {
+      if (!renderProfile) {
+        return null
+      }
+
+      return renderProfile(address)
+    },
+    [renderProfile]
+  )
+
+  return {
+    notifications: notificationsState.notifications,
+    isLoading: notificationsState.isLoading,
+    isModalOpen: uiState.isOpen,
+    modalActiveTab: uiState.activeTab,
+    isNotificationsOnboarding: uiState.isOnboarding,
+    handleOnBegin,
+    handleNotificationsOpen,
+    handleOnChangeModalTab,
+    handleRenderProfile,
+  }
+}
+
+export { checkIsOnboarding, setOnboardingDone, useNotifications }

--- a/src/hooks/useNotifications/useNotifications.type.ts
+++ b/src/hooks/useNotifications/useNotifications.type.ts
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react"
+
+enum NotificationActiveTab {
+  NEWEST = "newest",
+  READ = "read",
+}
+
+type NotificationItem = {
+  id: string
+  type: string
+  read: boolean
+  [key: string]: unknown
+}
+
+type NotificationsClient = {
+  getNotifications: () => Promise<NotificationItem[]>
+  markNotificationsAsRead: (ids: string[]) => Promise<void>
+}
+
+type NotificationsState = {
+  isLoading: boolean
+  notifications: NotificationItem[]
+}
+
+type NotificationsUIState = {
+  activeTab: string
+  isOnboarding: boolean
+  isOpen: boolean
+}
+
+type UseNotificationsOptions = {
+  identity?: unknown
+  isNotificationsEnabled: boolean
+  notificationsUrl: string
+  availableNotificationTypes?: string[]
+  queryIntervalMs?: number
+  initialActiveTab?: string
+  onError?: (error: Error) => void
+  renderProfile?: (address: string) => ReactNode
+}
+
+type UseNotificationsResult = {
+  notifications: NotificationItem[]
+  isLoading: boolean
+  isModalOpen: boolean
+  modalActiveTab: string
+  isNotificationsOnboarding: boolean
+  handleOnBegin: () => void
+  handleNotificationsOpen: () => void
+  handleOnChangeModalTab: (tab: string) => void
+  handleRenderProfile: (address: string) => ReactNode
+}
+
+export { NotificationActiveTab }
+export type {
+  NotificationItem,
+  NotificationsClient,
+  NotificationsState,
+  NotificationsUIState,
+  UseNotificationsOptions,
+  UseNotificationsResult,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
+export * from "./clients"
 export * from "./contexts"
 export * from "./hooks"
+export * from "./utils"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { getStorageItem, removeStorageItem, setStorageItem } from "./storage"

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,64 @@
+/**
+ * Retrieves and parses a JSON value from localStorage.
+ * Returns the fallback value if the key doesn't exist, parsing fails,
+ * or localStorage throws an error.
+ *
+ * @template T - The expected type of the stored value
+ * @param key - The localStorage key to retrieve
+ * @param fallback - The value to return if retrieval fails
+ * @returns The parsed value or the fallback
+ *
+ * @example
+ * const isEnabled = getStorageItem<boolean>('feature_enabled', false)
+ * const user = getStorageItem<User | null>('current_user', null)
+ */
+const getStorageItem = <T>(key: string, fallback: T): T => {
+  try {
+    const value = localStorage.getItem(key)
+    if (value === null) {
+      return fallback
+    }
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
+/**
+ * Stores a value in localStorage as JSON.
+ * Silently fails if localStorage throws an error.
+ *
+ * @template T - The type of the value to store
+ * @param key - The localStorage key
+ * @param value - The value to store (will be JSON stringified)
+ *
+ * @example
+ * setStorageItem('feature_enabled', true)
+ * setStorageItem('current_user', { id: 1, name: 'John' })
+ */
+const setStorageItem = <T>(key: string, value: T): void => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/**
+ * Removes a key from localStorage.
+ * Silently fails if localStorage throws an error.
+ *
+ * @param key - The localStorage key to remove
+ *
+ * @example
+ * removeStorageItem('current_user')
+ */
+const removeStorageItem = (key: string): void => {
+  try {
+    localStorage.removeItem(key)
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export { getStorageItem, removeStorageItem, setStorageItem }

--- a/test/__mocks__/decentraland-crypto-fetch.ts
+++ b/test/__mocks__/decentraland-crypto-fetch.ts
@@ -1,0 +1,8 @@
+const signedFetchFactory = () => {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    json: jest.fn().mockResolvedValue({ notifications: [] }),
+  })
+}
+
+export { signedFetchFactory }

--- a/test/hooks/useNotifications.test.ts
+++ b/test/hooks/useNotifications.test.ts
@@ -1,0 +1,701 @@
+import { act, renderHook } from "@testing-library/react/pure"
+import { createNotificationsClient } from "../../src/clients/notifications"
+import { useNotifications } from "../../src/hooks/useNotifications"
+import type {
+  NotificationItem,
+  UseNotificationsOptions,
+  UseNotificationsResult,
+} from "../../src/hooks/useNotifications"
+
+jest.mock("../../src/clients/notifications", () => ({
+  createNotificationsClient: jest.fn(),
+}))
+
+const mockCreateDCLNotificationsClient = createNotificationsClient as jest.Mock
+
+type TestResult = UseNotificationsResult
+
+const flushPromises = () => Promise.resolve()
+
+const createDeferred = <T>() => {
+  let resolve: (value: T) => void = () => undefined
+  let reject: (reason?: unknown) => void = () => undefined
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+describe("useNotifications", () => {
+  describe("when the hook mounts", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let initialState: TestResult
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+
+    beforeEach(() => {
+      getNotifications = jest.fn().mockResolvedValue([])
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: undefined,
+        isNotificationsEnabled: false,
+        notificationsUrl: "https://notifications.test.com",
+        initialActiveTab: "newest",
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      initialState = result.current
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should expose the initial state when the hook mounts", () => {
+      expect(initialState).toMatchObject({
+        isLoading: false,
+        notifications: [],
+        isModalOpen: false,
+        modalActiveTab: "newest",
+        isNotificationsOnboarding: true,
+      })
+    })
+  })
+
+  describe("when toggling the modal", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+    let isModalOpen: boolean
+
+    beforeEach(() => {
+      getNotifications = jest.fn().mockResolvedValue([])
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: undefined,
+        isNotificationsEnabled: false,
+        notificationsUrl: "https://notifications.test.com",
+        initialActiveTab: "newest",
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      act(() => {
+        result.current.handleNotificationsOpen()
+      })
+      isModalOpen = result.current.isModalOpen
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should open the modal when the toggle handler is called", () => {
+      expect(isModalOpen).toBe(true)
+    })
+  })
+
+  describe("when changing the active tab", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+    let activeTab: string
+
+    beforeEach(() => {
+      getNotifications = jest.fn().mockResolvedValue([])
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: undefined,
+        isNotificationsEnabled: false,
+        notificationsUrl: "https://notifications.test.com",
+        initialActiveTab: "newest",
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      act(() => {
+        result.current.handleOnChangeModalTab("unread")
+      })
+      activeTab = result.current.modalActiveTab
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should update the active tab when the tab handler is called", () => {
+      expect(activeTab).toBe("unread")
+    })
+  })
+
+  describe("when onboarding begins", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+    let isOnboarding: boolean
+
+    beforeEach(() => {
+      getNotifications = jest.fn().mockResolvedValue([])
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: undefined,
+        isNotificationsEnabled: false,
+        notificationsUrl: "https://notifications.test.com",
+        initialActiveTab: "newest",
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      act(() => {
+        result.current.handleOnBegin()
+      })
+      isOnboarding = result.current.isNotificationsOnboarding
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should disable onboarding when the begin handler is called", () => {
+      expect(isOnboarding).toBe(false)
+    })
+  })
+
+  describe("when notifications are enabled", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+    let notifications: NotificationItem[]
+
+    beforeEach(async () => {
+      notifications = [
+        { id: "1", type: "welcome", read: false },
+        { id: "2", type: "event", read: true },
+      ]
+      getNotifications = jest.fn().mockResolvedValue(notifications)
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: { address: "0x1" },
+        isNotificationsEnabled: true,
+        notificationsUrl: "https://notifications.test.com",
+        queryIntervalMs: 60000,
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      await act(async () => {
+        await flushPromises()
+      })
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should request notifications when identity is provided", () => {
+      expect(getNotifications).toHaveBeenCalledTimes(1)
+    })
+
+    it("should expose notifications when the client resolves", () => {
+      expect(result.current.notifications).toEqual(notifications)
+    })
+  })
+
+  describe("when read notifications are received", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+    let isOnboarding: boolean
+
+    beforeEach(async () => {
+      getNotifications = jest
+        .fn()
+        .mockResolvedValue([{ id: "1", type: "welcome", read: true }])
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: { address: "0x1" },
+        isNotificationsEnabled: true,
+        notificationsUrl: "https://notifications.test.com",
+        queryIntervalMs: 60000,
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      await act(async () => {
+        await flushPromises()
+      })
+      isOnboarding = result.current.isNotificationsOnboarding
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should disable onboarding when there are read notifications", () => {
+      expect(isOnboarding).toBe(false)
+    })
+  })
+
+  describe("when notifications are loading", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+    let isLoading: boolean
+    let deferred: ReturnType<typeof createDeferred<NotificationItem[]>>
+
+    beforeEach(async () => {
+      deferred = createDeferred<NotificationItem[]>()
+      getNotifications = jest.fn().mockReturnValue(deferred.promise)
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: { address: "0x1" },
+        isNotificationsEnabled: true,
+        notificationsUrl: "https://notifications.test.com",
+        queryIntervalMs: 60000,
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      await act(async () => {
+        await flushPromises()
+      })
+      isLoading = result.current.isLoading
+      deferred.resolve([])
+      await act(async () => {
+        await flushPromises()
+      })
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should set loading to true when the request is pending", () => {
+      expect(isLoading).toBe(true)
+    })
+  })
+
+  describe("when available notification types are provided", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+    let filteredNotifications: NotificationItem[]
+    let notifications: NotificationItem[]
+
+    beforeEach(async () => {
+      notifications = [
+        { id: "1", type: "allowed", read: false },
+        { id: "2", type: "blocked", read: true },
+      ]
+      getNotifications = jest.fn().mockResolvedValue(notifications)
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: { address: "0x1" },
+        isNotificationsEnabled: true,
+        notificationsUrl: "https://notifications.test.com",
+        availableNotificationTypes: ["allowed"],
+        queryIntervalMs: 60000,
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      await act(async () => {
+        await flushPromises()
+      })
+      filteredNotifications = result.current.notifications
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should filter notifications when types are restricted", () => {
+      expect(filteredNotifications).toEqual([notifications[0]])
+    })
+  })
+
+  describe("when notification fetching fails", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let onError: jest.Mock
+    let error: Error
+    let consoleErrorSpy: jest.SpyInstance
+
+    beforeEach(async () => {
+      error = new Error("Test error")
+      onError = jest.fn()
+      consoleErrorSpy = jest.spyOn(console, "error").mockImplementation()
+      getNotifications = jest.fn().mockRejectedValue(error)
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: { address: "0x1" },
+        isNotificationsEnabled: true,
+        notificationsUrl: "https://notifications.test.com",
+        onError,
+        queryIntervalMs: 60000,
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      await act(async () => {
+        await flushPromises()
+      })
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      consoleErrorSpy.mockRestore()
+      jest.resetAllMocks()
+    })
+
+    it("should report errors when the client rejects", () => {
+      expect(onError).toHaveBeenCalledWith(error)
+    })
+  })
+
+  describe("when closing the modal with unread notifications", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+    let notifications: NotificationItem[]
+
+    beforeEach(async () => {
+      notifications = [
+        { id: "1", type: "welcome", read: false },
+        { id: "2", type: "event", read: true },
+      ]
+      getNotifications = jest.fn().mockResolvedValue(notifications)
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: { address: "0x1" },
+        isNotificationsEnabled: true,
+        notificationsUrl: "https://notifications.test.com",
+        queryIntervalMs: 60000,
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      await act(async () => {
+        await flushPromises()
+      })
+      act(() => {
+        result.current.handleNotificationsOpen()
+      })
+      act(() => {
+        result.current.handleNotificationsOpen()
+      })
+      await act(async () => {
+        await flushPromises()
+      })
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should mark unread notifications when the modal closes", () => {
+      expect(markNotificationsAsRead).toHaveBeenCalledWith(["1"])
+    })
+  })
+
+  describe("when closing the modal updates notification reads", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+    let updatedNotifications: NotificationItem[]
+
+    beforeEach(async () => {
+      getNotifications = jest.fn().mockResolvedValue([
+        { id: "1", type: "welcome", read: false },
+        { id: "2", type: "event", read: true },
+      ])
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: { address: "0x1" },
+        isNotificationsEnabled: true,
+        notificationsUrl: "https://notifications.test.com",
+        queryIntervalMs: 60000,
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      await act(async () => {
+        await flushPromises()
+      })
+      act(() => {
+        result.current.handleNotificationsOpen()
+      })
+      act(() => {
+        result.current.handleNotificationsOpen()
+      })
+      await act(async () => {
+        await flushPromises()
+      })
+      updatedNotifications = result.current.notifications
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should update notification reads when the modal closes", () => {
+      expect(updatedNotifications).toEqual([
+        { id: "1", type: "welcome", read: true },
+        { id: "2", type: "event", read: true },
+      ])
+    })
+  })
+
+  describe("when notifications are disabled", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+
+    beforeEach(async () => {
+      getNotifications = jest.fn().mockResolvedValue([])
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: { address: "0x1" },
+        isNotificationsEnabled: false,
+        notificationsUrl: "https://notifications.test.com",
+        queryIntervalMs: 60000,
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      await act(async () => {
+        await flushPromises()
+      })
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should skip fetching when notifications are disabled", () => {
+      expect(getNotifications).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when identity is missing", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+
+    beforeEach(async () => {
+      getNotifications = jest.fn().mockResolvedValue([])
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: undefined,
+        isNotificationsEnabled: true,
+        notificationsUrl: "https://notifications.test.com",
+        queryIntervalMs: 60000,
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      await act(async () => {
+        await flushPromises()
+      })
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should not create a client when identity is missing", () => {
+      expect(mockCreateDCLNotificationsClient).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when the hook unmounts", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let pollCount: number
+
+    beforeEach(async () => {
+      jest.useFakeTimers()
+      getNotifications = jest.fn().mockResolvedValue([])
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: { address: "0x1" },
+        isNotificationsEnabled: true,
+        notificationsUrl: "https://notifications.test.com",
+        queryIntervalMs: 1000,
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      await act(async () => {
+        await flushPromises()
+      })
+      renderResult.unmount()
+      act(() => {
+        jest.advanceTimersByTime(2000)
+      })
+      pollCount = getNotifications.mock.calls.length
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+      jest.resetAllMocks()
+    })
+
+    it("should stop polling when the hook unmounts", () => {
+      expect(pollCount).toBe(1)
+    })
+  })
+
+  describe("when renderProfile is not provided", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+    let profileNode: unknown
+
+    beforeEach(() => {
+      getNotifications = jest.fn().mockResolvedValue([])
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: undefined,
+        isNotificationsEnabled: false,
+        notificationsUrl: "https://notifications.test.com",
+        initialActiveTab: "newest",
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      profileNode = result.current.handleRenderProfile("0x1")
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should return null when no renderProfile is provided", () => {
+      expect(profileNode).toBeNull()
+    })
+  })
+
+  describe("when renderProfile is provided", () => {
+    let getNotifications: jest.Mock
+    let markNotificationsAsRead: jest.Mock
+    let options: UseNotificationsOptions
+    let renderResult: ReturnType<typeof renderHook>
+    let result: { current: TestResult }
+    let profileNode: string | null
+    let renderProfile: jest.Mock
+
+    beforeEach(() => {
+      renderProfile = jest.fn().mockReturnValue("profile")
+      getNotifications = jest.fn().mockResolvedValue([])
+      markNotificationsAsRead = jest.fn().mockResolvedValue(undefined)
+      mockCreateDCLNotificationsClient.mockReturnValue({
+        getNotifications,
+        markNotificationsAsRead,
+      })
+      options = {
+        identity: undefined,
+        isNotificationsEnabled: false,
+        notificationsUrl: "https://notifications.test.com",
+        initialActiveTab: "newest",
+        renderProfile,
+      }
+      renderResult = renderHook(() => useNotifications(options))
+      result = renderResult.result as { current: TestResult }
+      profileNode = result.current.handleRenderProfile("0x1") as string | null
+    })
+
+    afterEach(() => {
+      renderResult.unmount()
+      jest.resetAllMocks()
+    })
+
+    it("should return the renderProfile result when a renderer is provided", () => {
+      expect(profileNode).toBe("profile")
+    })
+  })
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -17,3 +17,11 @@ Object.defineProperty(global, "TextEncoder", {
 Object.defineProperty(global, "TextDecoder", {
   value: MockTextDecoder,
 })
+
+jest.mock("decentraland-crypto-fetch", () => ({
+  signedFetchFactory: () =>
+    jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ notifications: [] }),
+    }),
+}))

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -18,10 +18,6 @@ Object.defineProperty(global, "TextDecoder", {
   value: MockTextDecoder,
 })
 
-jest.mock("decentraland-crypto-fetch", () => ({
-  signedFetchFactory: () =>
-    jest.fn().mockResolvedValue({
-      ok: true,
-      json: jest.fn().mockResolvedValue({ notifications: [] }),
-    }),
-}))
+jest.mock("decentraland-crypto-fetch", () =>
+  require("./__mocks__/decentraland-crypto-fetch")
+)


### PR DESCRIPTION
Adds a notifications flow to `@dcl/hooks`: a `useNotifications` hook and a `createNotificationsClient` for the Decentraland notifications API.

## Changes
- **useNotifications** – Handles notification polling, modal open/close, active tab, onboarding (localStorage), and marking as read on close. Requires `identity`, `isNotificationsEnabled`, and `notificationsUrl` (env-agnostic).
- **createNotificationsClient** – Builds the notifications client from `decentraland-crypto-fetch`; used internally by the hook. Accepts `url` and optional `limit`.
- **Storage utils** – `getStorageItem`, `setStorageItem`, `removeStorageItem` in `src/utils/storage` for onboarding persistence.

